### PR TITLE
Avoid redirects with custom port dropped

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -24,6 +24,11 @@ server {
         proxy_redirect off;
     }
 
+    location = /admin {
+        absolute_redirect off;
+        return 301 /admin/;
+    }
+
     location /static/ {
         autoindex on;
         alias /static/;

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -6,7 +6,7 @@ server {
 
     location / {
         root /var/www/html;
-        try_files $uri $uri/ /index.html;
+        try_files $uri /index.html;
     }
 
     location /v1/ {


### PR DESCRIPTION
Consider environment where doccano is running on custom port. This can be easily done by changing host port in https://github.com/chakki-works/doccano/blob/d4b7c89647afa4d3f44e2b83aad4eb5ca59b2877/docker-compose.prod.yml#L32-L33

In this case `/projects` request (no slash at the end) will generate the following response:
```
$ curl -I localhost:4285/projects 2>/dev/null
HTTP/1.1 301 Moved Permanently
Server: nginx
Date: Wed, 27 Nov 2019 09:57:27 GMT
Content-Type: text/html
Content-Length: 162
Location: http://localhost/projects/
Connection: keep-alive
X-Frame-Options: DENY
```
Please note that custom port 4285 is not included in the `Location` header value.

Here is response with changes included in the PR:
```
$ curl -I localhost:4285/projects 2>/dev/null
HTTP/1.1 200 OK
Server: nginx
Date: Wed, 27 Nov 2019 10:04:25 GMT
Content-Type: text/html; charset=utf-8
Content-Length: 3095
Last-Modified: Fri, 22 Nov 2019 10:07:22 GMT
Connection: keep-alive
ETag: "5dd7b35a-c17"
X-Frame-Options: DENY
Accept-Ranges: bytes

<!doctype html>
<html>
  <head>
projects page content...
```
Redirect is avoided here completely, and client would see either auth page (when not authorized) or projects list page. Other pages work fine too.

I'm not too familiar with nginx confligration options and there might be a better solution. If you find one I'll be happy to update the PR.