### PR TITLE
Enhancement/Document-level annotation guideline

### DIFF
--- a/app/server/static/components/annotation.pug
+++ b/app/server/static/components/annotation.pug
@@ -103,7 +103,7 @@ div.columns(v-cloak="")
           )
         section.modal-card-body.modal-card-body-footer
           vue-json-pretty(
-            v-bind:data="documentMetadata"
+            v-bind:data="displayDocumentMetadata"
             v-bind:show-double-quotes="false"
             v-bind:show-line="false"
           )

--- a/app/server/static/components/annotationMixin.js
+++ b/app/server/static/components/annotationMixin.js
@@ -273,7 +273,13 @@ export default {
     },
 
     compiledMarkdown() {
-      return marked(this.guideline, {
+      const documentMetadata = this.documentMetadata;
+
+      const guideline = documentMetadata && documentMetadata.guideline
+        ? documentMetadata.guideline
+        : this.guideline;
+
+      return marked(guideline, {
         sanitize: true,
       });
     },

--- a/app/server/static/components/annotationMixin.js
+++ b/app/server/static/components/annotationMixin.js
@@ -297,6 +297,18 @@ export default {
         : 'Click to approve annotations';
     },
 
+    displayDocumentMetadata() {
+      let documentMetadata = this.documentMetadata;
+      if (documentMetadata == null) {
+        return null;
+      }
+
+      documentMetadata = { ...documentMetadata };
+      delete documentMetadata.guideline;
+      delete documentMetadata.documentSourceUrl;
+      return documentMetadata;
+    },
+
     documentMetadata() {
       const document = this.docs[this.pageNumber];
       if (document == null || document.meta == null) {


### PR DESCRIPTION
Doccano currently supports project-level annotation guidelines which is a very useful tool to help labelers in their work. However, in some scenarios it can be helpful to also provide additional context to a labeler on a document-level, e.g. if the vocabularies of some documents vary wildly or if the classification in may depend on domain knowledge beyond the immediate document content.

This pull request implements document-level annotation guidelines: if a document has the metadata key "guideline", the content of this field will be rendered in the guideline display instead of the project-level guideline. If the "guideline" metadata key is not present, the project-level guideline is displayed as previously.

![Animation showing display of document-level and project-level guideline](https://user-images.githubusercontent.com/1086421/70306643-1b718c80-1853-11ea-852a-6edccaf60ae8.gif)

Given that this pull request introduces a second "magic" metadata value after documentSourceUrl introduced in https://github.com/doccano/doccano/pull/269, this pull request also adds functionality to exclude the "magic" metadata values from the display of the document metadata to avoid cluttering up the screen.