### PR TITLE
Enhancement/Verification emails on Azure

### DIFF
--- a/app/app/settings.py
+++ b/app/app/settings.py
@@ -296,12 +296,12 @@ APPLICATION_INSIGHTS = {
     'endpoint': env('AZURE_APPINSIGHTS_ENDPOINT', None),
 }
 
-## necessary for email verification setup
-# EMAIL_USE_TLS = True
-# EMAIL_HOST = 'smtp.gmail.com'
-# EMAIL_HOST_USER = 'random@gmail.com'
-# EMAIL_HOST_PASSWORD = 'gfds6jk#4ljIr%G8%'
-# EMAIL_PORT = 587
-#
-## During development only
-# EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
+# necessary for email verification of new accounts
+EMAIL_USE_TLS = env.bool('EMAIL_USE_TLS', False)
+EMAIL_HOST = env('EMAIL_HOST', None)
+EMAIL_HOST_USER = env('EMAIL_HOST_USER', None)
+EMAIL_HOST_PASSWORD = env('EMAIL_HOST_PASSWORD', None)
+EMAIL_PORT = env.int('EMAIL_PORT', 587)
+
+if not EMAIL_HOST:
+    EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'

--- a/app/authentification/templates/acc_active_email.html
+++ b/app/authentification/templates/acc_active_email.html
@@ -1,5 +1,5 @@
 {% autoescape off %}
 Hi {{ user.username }},
 Please click on the link to confirm your email,
-http://{{ domain }}{% url 'activate' uidb64=uid token=token %}
+{{ scheme }}://{{ domain }}{% url 'activate' uidb64=uid token=token %}
 {% endautoescape %}

--- a/app/authentification/templates/acc_active_email.html
+++ b/app/authentification/templates/acc_active_email.html
@@ -1,5 +1,5 @@
 {% autoescape off %}
 Hi {{ user.username }},
-Please click on the link to confirm your email,
+Please click on the link to confirm your email and activate your Doccano account:
 {{ scheme }}://{{ domain }}{% url 'activate' uidb64=uid token=token %}
 {% endautoescape %}

--- a/app/authentification/views.py
+++ b/app/authentification/views.py
@@ -39,6 +39,7 @@ class SignupView(TemplateView):
             message = render_to_string('acc_active_email.html', {
                 'user': user,
                 'domain': current_site.domain,
+                'scheme': request.scheme,
                 'uid': urlsafe_base64_encode(force_bytes(user.pk)).decode(),
                 'token': account_activation_token.make_token(user),
             })

--- a/azuredeploy.json
+++ b/azuredeploy.json
@@ -33,6 +33,7 @@
     "adminPassword": {
       "type": "securestring",
       "minLength": 16,
+      "maxLength": 50,
       "metadata": {
         "description": "The password for the admin account."
       }
@@ -50,6 +51,21 @@
       ],
       "metadata": {
         "description": "The SKU of the webapp hosting tier."
+      }
+    },
+    "sendgridSku": {
+      "type": "string",
+      "defaultValue": "free",
+      "allowedValues": [
+        "free",
+        "bronze",
+        "silver",
+        "gold",
+        "platinum",
+        "premier"
+      ],
+      "metadata": {
+        "description": "The SKU of the Sendgrid email account."
       }
     },
     "databaseCores": {
@@ -124,11 +140,29 @@
     "databaseUserCredentials" : "[concat(uriComponent(concat(parameters('adminUserName'), '@', variables('databaseServerName'))), ':', parameters('adminPassword'))]",
     "databaseFqdn" : "[concat( variables('databaseServerName'), '.postgres.database.azure.com:', variables('databaseServerPort'))]",
     "databaseConnectionString": "[concat('pgsql://', variables('databaseUserCredentials'), '@', variables('databaseFqdn'), '/', parameters('databaseName'))]",
+    "sendgridAccountName": "[concat(parameters('appName'),'-email')]",
     "appServicePlanName": "[concat(parameters('appName'),'-hosting')]",
     "analyticsName": "[concat(parameters('appName'),'-analytics')]",
     "appFqdn": "[concat(parameters('appName'),'.azurewebsites.net')]"
   },
   "resources": [
+    {
+      "name": "[variables('sendgridAccountName')]",
+      "type": "Sendgrid.Email/accounts",
+      "apiVersion": "2015-01-01",
+      "location": "[variables('location')]",
+      "plan": {
+        "name": "[parameters('sendgridSku')]",
+        "publisher": "Sendgrid",
+        "product": "sendgrid_azure",
+        "promotionCode": ""
+      },
+      "properties": {
+        "acceptMarketingEmails": false,
+        "email": "[parameters('adminContactEmail')]",
+        "password": "[parameters('adminPassword')]"
+      }
+    },
     {
       "type": "Microsoft.Insights/components",
       "apiVersion": "2015-05-01",
@@ -207,6 +241,7 @@
       "kind": "app,linux,container",
       "location": "[variables('location')]",
       "dependsOn": [
+        "[resourceId('Sendgrid.Email/accounts', variables('sendgridAccountName'))]",
         "[resourceId('Microsoft.DBforPostgreSQL/servers/', variables('databaseServerName'))]",
         "[resourceId('Microsoft.Insights/components', variables('analyticsName'))]",
         "[resourceId('Microsoft.Web/serverfarms', variables('appServicePlanName'))]"
@@ -260,6 +295,26 @@
             {
               "name": "ADMIN_PASSWORD",
               "value": "[parameters('adminPassword')]"
+            },
+            {
+              "name": "EMAIL_USE_TLS",
+              "value": "True"
+            },
+            {
+              "name": "EMAIL_HOST",
+              "value": "[reference(resourceId('Sendgrid.Email/accounts', variables('sendgridAccountName'))).smtpServer]"
+            },
+            {
+              "name": "EMAIL_HOST_USER",
+              "value": "[reference(resourceId('Sendgrid.Email/accounts', variables('sendgridAccountName'))).username]"
+            },
+            {
+              "name": "EMAIL_HOST_PASSWORD",
+              "value": "[parameters('adminPassword')]"
+            },
+            {
+              "name": "EMAIL_PORT",
+              "value": "587"
             },
             {
               "name": "DEBUG",


### PR DESCRIPTION
In https://github.com/doccano/doccano/pull/250, @guillim introduced the ability for users to self-service sign-up for new Doccano accounts. This pull request ensures that the sign-up functionality works out-of-the-box in the Azure deployment which required a few changes:

1. Enabling configuring the email backend settings via environment variables so that deployments can turn on the feature without requiring a code change.
2. Removing hard-coded HTTP scheme the activation link sent in activation email so that the link also works on deployments that use HTTPS.
3. Adding a Sendgrid resource to the Azure deployment. By default this uses the free tier which covers 25,000 emails per month (see [pricing](https://azuremarketplace.microsoft.com/en-us/marketplace/apps/SendGrid.SendGrid?tab=PlansAndPrice)).

Additionally, the wording of the account activation email has been slightly changed to ensure that users know that the email comes from Doccano and we now default to the console email backend to prevent crashes when running locally.