### PR TITLE
Bugfix/Fix collaborative annotation for stats and filter

### DIFF
--- a/app/api/filters.py
+++ b/app/api/filters.py
@@ -12,7 +12,7 @@ class DocumentFilter(FilterSet):
     def filter_annotations(self, queryset, field_name, value):
         queryset = queryset.annotate(num_annotations=
             Count(field_name, filter=
-                Q(**{ f"{field_name}__user": self.request.user})))
+                Q(**{ f"{field_name}__user": self.request.user}) | Q(project__collaborative_annotation=True)))
 
         should_have_annotations = not value
         if should_have_annotations:

--- a/app/api/tests/test_api.py
+++ b/app/api/tests/test_api.py
@@ -29,6 +29,19 @@ def remove_all_role_mappings():
     RoleMapping.objects.all().delete()
 
 
+class TestUtilsMixin:
+    def _patch_project(self, project, attribute, value):
+        old_value = getattr(project, attribute, None)
+        setattr(project, attribute, value)
+        project.save()
+
+        def cleanup_project():
+            setattr(project, attribute, old_value)
+            project.save()
+
+        self.addCleanup(cleanup_project)
+
+
 @override_settings(STATICFILES_STORAGE='django.contrib.staticfiles.storage.StaticFilesStorage')
 class TestProjectListAPI(APITestCase):
 
@@ -604,7 +617,7 @@ class TestApproveLabelsAPI(APITestCase):
         remove_all_role_mappings()
 
 
-class TestAnnotationListAPI(APITestCase):
+class TestAnnotationListAPI(APITestCase, TestUtilsMixin):
 
     @classmethod
     def setUpTestData(cls):

--- a/app/api/tests/test_api.py
+++ b/app/api/tests/test_api.py
@@ -1332,10 +1332,8 @@ class TestStatisticsAPI(APITestCase):
         self.client.login(username=self.super_user_name,
                           password=self.super_user_pass)
         response = self.client.get(self.url, format='json')
-        total = self.doc.count()
-        remaining = self.doc.filter(doc_annotations__isnull=True).count()
-        self.assertEqual(response.data['total'], total)
-        self.assertEqual(response.data['remaining'], remaining)
+        self.assertEqual(response.data['total'], 2)
+        self.assertEqual(response.data['remaining'], 1)
 
     def test_returns_user_count(self):
         self.client.login(username=self.super_user_name,

--- a/app/api/tests/test_api.py
+++ b/app/api/tests/test_api.py
@@ -376,7 +376,7 @@ class TestLabelDetailAPI(APITestCase):
         remove_all_role_mappings()
 
 
-class TestDocumentListAPI(APITestCase):
+class TestDocumentListAPI(APITestCase, TestUtilsMixin):
 
     @classmethod
     def setUpTestData(cls):
@@ -439,6 +439,32 @@ class TestDocumentListAPI(APITestCase):
         self._test_list('{}?doc_annotations__isnull=false'.format(self.url),
                         username=self.project_member_name,
                         password=self.project_member_pass,
+                        expected_num_results=2)
+
+    def test_returns_docs_to_project_member_filtered_to_active_with_collaborative_annotation(self):
+        self._test_list('{}?doc_annotations__isnull=true'.format(self.url),
+                        username=self.super_user_name,
+                        password=self.super_user_pass,
+                        expected_num_results=3)
+
+        self._patch_project(self.main_project, 'collaborative_annotation', True)
+
+        self._test_list('{}?doc_annotations__isnull=true'.format(self.url),
+                        username=self.super_user_name,
+                        password=self.super_user_pass,
+                        expected_num_results=1)
+
+    def test_returns_docs_to_project_member_filtered_to_completed_with_collaborative_annotation(self):
+        self._test_list('{}?doc_annotations__isnull=false'.format(self.url),
+                        username=self.super_user_name,
+                        password=self.super_user_pass,
+                        expected_num_results=0)
+
+        self._patch_project(self.main_project, 'collaborative_annotation', True)
+
+        self._test_list('{}?doc_annotations__isnull=false'.format(self.url),
+                        username=self.super_user_name,
+                        password=self.super_user_pass,
                         expected_num_results=2)
 
     def test_returns_docs_in_consistent_order_for_all_users(self):


### PR DESCRIPTION
Currently [AnnotationList](https://github.com/doccano/doccano/blob/72cafaf881aa239393566278613a725c35b60ee8/app/api/views.py#L180-L181) respects the `project.collaborative_annotation` property. However, [DocumentList](https://github.com/doccano/doccano/blob/72cafaf881aa239393566278613a725c35b60ee8/app/api/views.py#L145-L152) and [DocumentFilter](https://github.com/doccano/doccano/blob/72cafaf881aa239393566278613a725c35b60ee8/app/api/filters.py#L12-L23) do not currently respect the property. This pull request fixes that issue.

Fixes https://github.com/doccano/doccano/issues/525