### PR TITLE
Bugfix/Flags set on project creation are discarded

### DIFF
--- a/app/api/admin.py
+++ b/app/api/admin.py
@@ -19,7 +19,7 @@ class DocumentAdmin(admin.ModelAdmin):
 
 
 class ProjectAdmin(admin.ModelAdmin):
-    list_display = ('name', 'description', 'project_type', 'randomize_document_order')
+    list_display = ('name', 'description', 'project_type', 'randomize_document_order', 'collaborative_annotation')
     ordering = ('project_type',)
     search_fields = ('name',)
 

--- a/app/api/serializers.py
+++ b/app/api/serializers.py
@@ -120,7 +120,6 @@ class TextClassificationProjectSerializer(ProjectSerializer):
 
 class SequenceLabelingProjectSerializer(ProjectSerializer):
 
-
     class Meta:
         model = SequenceLabelingProject
         fields = ('id', 'name', 'description', 'guideline', 'users', 'current_users_role', 'project_type', 'image',

--- a/app/api/serializers.py
+++ b/app/api/serializers.py
@@ -113,8 +113,7 @@ class TextClassificationProjectSerializer(ProjectSerializer):
 
     class Meta:
         model = TextClassificationProject
-        fields = ('id', 'name', 'description', 'guideline', 'users', 'current_users_role', 'project_type', 'image',
-                  'updated_at', 'randomize_document_order')
+        fields = ProjectSerializer.Meta.fields
         read_only_fields = ProjectSerializer.Meta.read_only_fields
 
 
@@ -122,8 +121,7 @@ class SequenceLabelingProjectSerializer(ProjectSerializer):
 
     class Meta:
         model = SequenceLabelingProject
-        fields = ('id', 'name', 'description', 'guideline', 'users', 'current_users_role', 'project_type', 'image',
-                  'updated_at', 'randomize_document_order')
+        fields = ProjectSerializer.Meta.fields
         read_only_fields = ProjectSerializer.Meta.read_only_fields
 
 
@@ -131,8 +129,7 @@ class Seq2seqProjectSerializer(ProjectSerializer):
 
     class Meta:
         model = Seq2seqProject
-        fields = ('id', 'name', 'description', 'guideline', 'users', 'current_users_role', 'project_type', 'image',
-                  'updated_at', 'randomize_document_order')
+        fields = ProjectSerializer.Meta.fields
         read_only_fields = ProjectSerializer.Meta.read_only_fields
 
 

--- a/app/api/serializers.py
+++ b/app/api/serializers.py
@@ -106,7 +106,7 @@ class ProjectSerializer(serializers.ModelSerializer):
         model = Project
         fields = ('id', 'name', 'description', 'guideline', 'users', 'current_users_role', 'project_type', 'image',
                   'updated_at', 'randomize_document_order', 'collaborative_annotation')
-        read_only_fields = ('image', 'updated_at', 'current_users_role')
+        read_only_fields = ('image', 'updated_at', 'users', 'current_users_role')
 
 
 class TextClassificationProjectSerializer(ProjectSerializer):
@@ -115,7 +115,7 @@ class TextClassificationProjectSerializer(ProjectSerializer):
         model = TextClassificationProject
         fields = ('id', 'name', 'description', 'guideline', 'users', 'current_users_role', 'project_type', 'image',
                   'updated_at', 'randomize_document_order')
-        read_only_fields = ('image', 'updated_at', 'users', 'current_users_role')
+        read_only_fields = ProjectSerializer.Meta.read_only_fields
 
 
 class SequenceLabelingProjectSerializer(ProjectSerializer):
@@ -124,7 +124,7 @@ class SequenceLabelingProjectSerializer(ProjectSerializer):
         model = SequenceLabelingProject
         fields = ('id', 'name', 'description', 'guideline', 'users', 'current_users_role', 'project_type', 'image',
                   'updated_at', 'randomize_document_order')
-        read_only_fields = ('image', 'updated_at', 'users', 'current_users_role')
+        read_only_fields = ProjectSerializer.Meta.read_only_fields
 
 
 class Seq2seqProjectSerializer(ProjectSerializer):
@@ -133,7 +133,7 @@ class Seq2seqProjectSerializer(ProjectSerializer):
         model = Seq2seqProject
         fields = ('id', 'name', 'description', 'guideline', 'users', 'current_users_role', 'project_type', 'image',
                   'updated_at', 'randomize_document_order')
-        read_only_fields = ('image', 'updated_at', 'users', 'current_users_role')
+        read_only_fields = ProjectSerializer.Meta.read_only_fields
 
 
 class ProjectPolymorphicSerializer(PolymorphicSerializer):

--- a/app/api/tests/test_api.py
+++ b/app/api/tests/test_api.py
@@ -111,6 +111,20 @@ class TestProjectListAPI(APITestCase):
                           password=self.super_user_pass)
         response = self.client.post(self.url, format='json', data=self.data)
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertFalse(response.json().get('collaborative_annotation'))
+        self.assertFalse(response.json().get('randomize_document_order'))
+
+    def test_allows_superuser_to_create_project_with_flags(self):
+        self.client.login(username=self.super_user_name,
+                          password=self.super_user_pass)
+        response = self.client.post(self.url, format='json', data=dict(
+            collaborative_annotation=True,
+            randomize_document_order=True,
+            **self.data,
+        ))
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertTrue(response.json().get('collaborative_annotation'))
+        self.assertTrue(response.json().get('randomize_document_order'))
 
     def test_disallows_project_member_to_create_project(self):
         self.client.login(username=self.main_project_member_name,

--- a/app/api/tests/test_api.py
+++ b/app/api/tests/test_api.py
@@ -117,11 +117,10 @@ class TestProjectListAPI(APITestCase):
     def test_allows_superuser_to_create_project_with_flags(self):
         self.client.login(username=self.super_user_name,
                           password=self.super_user_pass)
-        response = self.client.post(self.url, format='json', data=dict(
-            collaborative_annotation=True,
-            randomize_document_order=True,
-            **self.data,
-        ))
+        data = dict(self.data)
+        data['collaborative_annotation'] = True
+        data['randomize_document_order'] = True
+        response = self.client.post(self.url, format='json', data=data)
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         self.assertTrue(response.json().get('collaborative_annotation'))
         self.assertTrue(response.json().get('randomize_document_order'))


### PR DESCRIPTION
Currently if a project is created with the "share annotations across all users" checkbox ticked, the `collaborative_annotation` option isn't set in the created project. This is due to code duplication in the various `ProjectSerializer` subclasses which led to a drift in the `fields` and `read_only_fields` between the various subclasses. This pull request fixes the issue by removing the code duplication and having one canonical set of `fields` and `read_only_fields` which is consistent across all subclasses of the project serializer.

Resolves https://github.com/doccano/doccano/issues/519