### PR TITLE
Resolve build fail

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:13.1.0
+FROM node:13.2.0
 
 # set work directory
 WORKDIR /app


### PR DESCRIPTION
There's an upstream issue with babel which affects node.js 13.1.0 (see: https://github.com/babel/babel/pull/11006 ) which prevents doccano from building (see #526), even when rolling back to v1.0.2.

This can be resolved by upgrading to node.js 13.2.0