### PR TITLE
Feature/LDAP support

### DIFF
--- a/app/app/settings.py
+++ b/app/app/settings.py
@@ -14,6 +14,8 @@ from os import path
 
 import django_heroku
 import dj_database_url
+import ldap
+from django_auth_ldap.config import LDAPSearch
 from environs import Env
 from furl import furl
 
@@ -145,6 +147,21 @@ AUTHENTICATION_BACKENDS = [
     'social_core.backends.azuread_tenant.AzureADTenantOAuth2',
     'django.contrib.auth.backends.ModelBackend',
 ]
+
+AUTH_LDAP_SERVER_URI = env('AUTH_LDAP_SERVER_URI', None)
+
+if AUTH_LDAP_SERVER_URI:
+    AUTHENTICATION_BACKENDS.append('django_auth_ldap.backend.LDAPBackend')
+    AUTH_LDAP_ALWAYS_UPDATE_USER = env.bool('AUTH_LDAP_ALWAYS_UPDATE_USER', True)
+    AUTH_LDAP_BIND_DN = env('AUTH_LDAP_BIND_DN', None)
+    AUTH_LDAP_BIND_PASSWORD = env('AUTH_LDAP_BIND_PASSWORD', None)
+    AUTH_LDAP_USER_SEARCH = LDAPSearch(
+        env('AUTH_LDAP_USER_SEARCH_DN', None),
+        ldap.SCOPE_SUBTREE,
+        env('AUTH_LDAP_USER_SEARCH_BIND', None)
+    )
+    AUTH_LDAP_USER_ATTR_MAP = env('AUTH_LDAP_USER_ATTR_MAP', None)
+
 
 SOCIAL_AUTH_GITHUB_KEY = env('OAUTH_GITHUB_KEY', None)
 SOCIAL_AUTH_GITHUB_SECRET = env('OAUTH_GITHUB_SECRET', None)

--- a/app/app/settings.py
+++ b/app/app/settings.py
@@ -14,8 +14,6 @@ from os import path
 
 import django_heroku
 import dj_database_url
-import ldap
-from django_auth_ldap.config import LDAPSearch
 from environs import Env
 from furl import furl
 
@@ -153,14 +151,10 @@ AUTH_LDAP_SERVER_URI = env('AUTH_LDAP_SERVER_URI', None)
 if AUTH_LDAP_SERVER_URI:
     AUTHENTICATION_BACKENDS.append('django_auth_ldap.backend.LDAPBackend')
     AUTH_LDAP_ALWAYS_UPDATE_USER = env.bool('AUTH_LDAP_ALWAYS_UPDATE_USER', True)
-    AUTH_LDAP_BIND_DN = env('AUTH_LDAP_BIND_DN', None)
-    AUTH_LDAP_BIND_PASSWORD = env('AUTH_LDAP_BIND_PASSWORD', None)
-    AUTH_LDAP_USER_SEARCH = LDAPSearch(
-        env('AUTH_LDAP_USER_SEARCH_DN', None),
-        ldap.SCOPE_SUBTREE,
-        env('AUTH_LDAP_USER_SEARCH_BIND', None)
-    )
-    AUTH_LDAP_USER_ATTR_MAP = env('AUTH_LDAP_USER_ATTR_MAP', None)
+    AUTH_LDAP_BIND_DN = env('AUTH_LDAP_BIND_DN', '')
+    AUTH_LDAP_BIND_PASSWORD = env('AUTH_LDAP_BIND_PASSWORD', '')
+    AUTH_LDAP_USER_DN_TEMPLATE = env('AUTH_LDAP_USER_DN_TEMPLATE', None)
+    AUTH_LDAP_USER_ATTR_MAP = env('AUTH_LDAP_USER_ATTR_MAP', {})
 
 
 SOCIAL_AUTH_GITHUB_KEY = env('OAUTH_GITHUB_KEY', None)

--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -14,6 +14,7 @@ django-widget-tweaks==1.4.2
 django-polymorphic==2.0.3
 django-pyodbc-azure==2.1.0.0
 django-rest-polymorphic==0.1.8
+django-auth-ldap==2.1.0
 djangorestframework==3.10
 djangorestframework-csv==2.1.0
 djangorestframework-filters==0.10.2

--- a/docs/advanced/ldap_settings.md
+++ b/docs/advanced/ldap_settings.md
@@ -1,0 +1,41 @@
+# LDAP setup for doccano
+
+This document aims to instruct how to setup LDAP for doccano.
+
+## Set environment variables
+
+In general, the variable AUTH_LDAP_SERVER_URI is the variable that determines whether LDAP authentication is activated.
+
+If AUTH_LDAP_SERVER_URI is defined, than 'django_auth_ldap.backend.LDAPBackend' is added to AUTHENTICATION_BACKENDS. The standard django user authentication is also still available to assign permissions to individual users or add users to groups within Django.
+
+AUTH_LDAP_SERVER_URI defines the URI of the LDAP server.
+AUTH_LDAP_BIND_DN is the distinguished name to use when binding to the LDAP server (with AUTH_LDAP_BIND_PASSWORD). Use the empty string for an anonymous bind.
+AUTH_LDAP_USER_DN_TEMPLATE is a string template that describes any user’s distinguished name based on the username. This must contain the placeholder **%(user)s**.
+AUTH_LDAP_USER_ATTR_MAP is a mapping from User field names to LDAP attribute names. A users’s User object will be populated from his LDAP attributes at login.
+
+## Example configuration
+
+```
+AUTH_LDAP_SERVER_URI = "ldap://ldap.example.com"
+AUTH_LDAP_BIND_DN = "cn=django-agent,dc=example,dc=com"
+AUTH_LDAP_BIND_PASSWORD = "yoursecretpassword"
+AUTH_LDAP_USER_DN_TEMPLATE = 'uid=%(user)s,ou=users,dc=example,dc=com'
+AUTH_LDAP_USER_ATTR_MAP = {
+    "first_name": "givenName",
+    "last_name": "sn",
+    "email": "mail",
+}
+```
+
+## Run server
+
+```bash
+python manage.py runserver
+```
+
+Your LDAP login is now part of doccano's login page with its fields for username and password. As defined the provided username will be used for the LDAP user template.
+
+## Additional sources for configuration
+
+* <https://django-auth-ldap.readthedocs.io>
+* <https://www.python-ldap.org>

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -34,6 +34,7 @@ nav:
   - Advanced:
     - AWS HTTPS settings: advanced/aws_https_settings.md
     - OAuth2 settings: advanced/oauth2_settings.md
+    - LDAP settings: advanced/ldap_settings.md
   #- Release notes: release-notes.md
   #- Author's notes: authors-notes.md
   - FAQ: faq.md

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,6 +14,7 @@ django-widget-tweaks==1.4.2
 django-polymorphic==2.0.3
 django-pyodbc-azure==2.1.0.0
 django-rest-polymorphic==0.1.8
+django-auth-ldap==2.1.0
 djangorestframework==3.10
 djangorestframework-csv==2.1.0
 djangorestframework-filters==0.10.2


### PR DESCRIPTION
This pull request is about the [requested feature to be able to connect doccano to an LDAP server](https://github.com/doccano/doccano/issues/560).

LDAP support for doccano is for many organizations a very important feature since they already have an elaborated LDAP authentication infrastructure. Also group management is often included in their existing infrastructure.

The provided solution integrates seamlessly into doccano. Only another Django authentication backend and its configuration are needed. The configuration for LDAP should be part of the existing environment variables. Therefore it integrates well with the existing flow.

Since the LDAP authentication backend integrates well into Django applications, the existing login page of doccano doesn't need to be changed. Everything should work fine.