### PR TITLE
Instruct docker pull from chakkiworks/doccano

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ git clone https://github.com/doccano/doccano.git --config core.autocrlf=input
 As a one-time setup, create a Docker container for Doccano:
 
 ```bash
-docker pull doccano/doccano
+docker pull chakkiworks/doccano
 docker container create --name doccano \
   -e "ADMIN_USERNAME=admin" \
   -e "ADMIN_EMAIL=admin@example.com" \


### PR DESCRIPTION
Instructions for one-time docker setup specify **docker pull doccano/doccano**, but this fails with **Error response from daemon: pull access denied for docanno/docanno, repository does not exist or ...**.

Instructions that work are found In the [FAQ](https://github.com/doccano/doccano/wiki/Frequently-Asked-Questions#i-cant-install-doccano):  **Get doccano's image:    docker pull chakkiworks/doccano**.
