### PR TITLE
Added project name in sidebar

### DIFF
--- a/frontend/components/organisms/layout/TheSideBar.vue
+++ b/frontend/components/organisms/layout/TheSideBar.vue
@@ -1,5 +1,10 @@
 <template>
   <v-list dense>
+    <v-list-item>
+      <h1 style="text-transform:capitalize;">
+        {{ currentProject.name }}
+      </h1>
+    </v-list-item>
     <v-btn
       :to="to"
       color="ms-4 my-1 mb-2 primary text-capitalize"
@@ -32,6 +37,8 @@
 </template>
 
 <script>
+import { mapGetters } from 'vuex'
+
 export default {
   props: {
     link: {
@@ -62,7 +69,8 @@ export default {
   computed: {
     to() {
       return `/projects/${this.$route.params.id}/${this.link}`
-    }
+    },
+    ...mapGetters('projects', ['currentProject'])
   },
 
   methods: {


### PR DESCRIPTION
Hey @Hironsan 

This fixes https://github.com/doccano/doccano/issues/621

I have added it in sidebar. PFB the images. 

![image](https://user-images.githubusercontent.com/2357025/79053663-9cef8600-7c5c-11ea-84e2-d33665b5c2bc.png)
![image](https://user-images.githubusercontent.com/2357025/79053668-ab3da200-7c5c-11ea-91e9-2b1d2e3dd362.png)
