### PR TITLE
change of permission for annotation edits

### DIFF
--- a/app/api/views.py
+++ b/app/api/views.py
@@ -212,7 +212,7 @@ class AnnotationList(generics.ListCreateAPIView):
 
 class AnnotationDetail(generics.RetrieveUpdateDestroyAPIView):
     lookup_url_kwarg = 'annotation_id'
-    permission_classes = [IsAuthenticated & (((IsAnnotator | IsAnnotationApprover) & IsOwnAnnotation) | IsProjectAdmin)]
+    permission_classes = [IsAuthenticated & (((IsAnnotator & IsOwnAnnotation) | IsAnnotationApprover)  | IsProjectAdmin)]
     swagger_schema = None
 
     def get_serializer_class(self):


### PR DESCRIPTION
Add of requested feature from deathg0d from issue [#703 ](https://github.com/doccano/doccano/issues/703)

Annotation Approvers are now able to remove and edit any annotations from other annotators while annotators can only remove their own annotations.
