### PR TITLE
Enhancement/avoid username is taken

### DIFF
--- a/app/server/management/commands/create_admin.py
+++ b/app/server/management/commands/create_admin.py
@@ -20,10 +20,9 @@ class Command(createsuperuser.Command):
 
         try:
             super().handle(*args, **options)
-        except IntegrityError:
+            self.stderr.write(f'try executed')
+        except (IntegrityError, CommandError) as e:
             self.stderr.write(f'User {username} already exists.')
-        except CommandError:
-            pass
 
         if password:
             database = options.get('database')

--- a/app/server/management/commands/create_admin.py
+++ b/app/server/management/commands/create_admin.py
@@ -20,8 +20,11 @@ class Command(createsuperuser.Command):
 
         try:
             super().handle(*args, **options)
-        except (IntegrityError, CommandError):
-            self.stderr.write(f'User {username} already exists.')
+        except Exception as err:
+            if 'is already taken' in str(err):
+                self.stderr.write(f'User {username} already exists.')
+            else:
+                raise
 
         if password:
             database = options.get('database')

--- a/app/server/management/commands/create_admin.py
+++ b/app/server/management/commands/create_admin.py
@@ -21,7 +21,7 @@ class Command(createsuperuser.Command):
         try:
             super().handle(*args, **options)
             self.stderr.write(f'try executed')
-        except (IntegrityError, CommandError) as e:
+        except (IntegrityError, CommandError):
             pass
 
         if password:

--- a/app/server/management/commands/create_admin.py
+++ b/app/server/management/commands/create_admin.py
@@ -22,6 +22,8 @@ class Command(createsuperuser.Command):
             super().handle(*args, **options)
         except IntegrityError:
             self.stderr.write(f'User {username} already exists.')
+        except CommandError:
+            pass
 
         if password:
             database = options.get('database')

--- a/app/server/management/commands/create_admin.py
+++ b/app/server/management/commands/create_admin.py
@@ -22,7 +22,7 @@ class Command(createsuperuser.Command):
             super().handle(*args, **options)
             self.stderr.write(f'try executed')
         except (IntegrityError, CommandError) as e:
-            self.stderr.write(f'User {username} already exists.')
+            pass
 
         if password:
             database = options.get('database')

--- a/app/server/management/commands/create_admin.py
+++ b/app/server/management/commands/create_admin.py
@@ -20,13 +20,13 @@ class Command(createsuperuser.Command):
 
         try:
             super().handle(*args, **options)
-            self.stderr.write(f'try executed')
         except (IntegrityError, CommandError):
-            pass
+            self.stderr.write(f'User {username} already exists.')
 
         if password:
             database = options.get('database')
             db = self.UserModel._default_manager.db_manager(database)
             user = db.get(username=username)
             user.set_password(password)
+            self.stderr.write(f'Setting password for User {username}.')
             user.save()


### PR DESCRIPTION
catching the exception that results in the error message:
`backend_1   | CommandError: Error: That username is already taken.`
this message was displayed at every startup and is now caught by the try catch block.

enhancement was requested in issue #738 