### PR TITLE
Remove legacy endpoint

### DIFF
--- a/frontend/nuxt.config.js
+++ b/frontend/nuxt.config.js
@@ -26,10 +26,6 @@ export default {
     ]
   },
 
-  serverMiddleware: [
-    '~/api/index.js'
-  ],
-
   server: {
     host: '0.0.0.0' // default: localhost
   },


### PR DESCRIPTION
As having this configured without a working backend will return dummy
data (projects) to the browser.

Fixes #789