### PR TITLE
chore: update documentation link

### DIFF
--- a/app/server/templates/index.html
+++ b/app/server/templates/index.html
@@ -173,7 +173,7 @@
         </h2>
         <ul>
           <li>
-            <a href="https://github.com/doccano/doccano">Documentation</a>
+            <a href="https://doccano.github.io/doccano/">Documentation</a>
           </li>
           <li>
             <a href="{% url 'demo-named-entity-recognition' %}">Live Demo</a>


### PR DESCRIPTION
Change documentation link to GitHub Pages, whether to add documentation link in the README file?

In addition, the images in the section about "AWS HTTPS settings" in the documentation are not accessible.

And also, the last of the three images at the bottom of the homepage is no longer accessible.

It looks like the version deployed on Heroku is not updated, it still use the old repository link.