### PR TITLE
When enabling `randomize_document_order`  the api returns top document on the dataset for every api call.

### DIFF
--- a/app/api/views.py
+++ b/app/api/views.py
@@ -161,10 +161,9 @@ class DocumentList(generics.ListCreateAPIView):
 
     def get_queryset(self):
         project = get_object_or_404(Project, pk=self.kwargs['project_id'])
-
         queryset = project.documents
         if project.randomize_document_order:
-            queryset = queryset.annotate(sort_id=F('id') % self.request.user.id).order_by('sort_id')
+            queryset = queryset.annotate(sort_id=F('id') % max(2, self.request.user.id)).order_by('sort_id')
         else:
             queryset = queryset.order_by('id')
 


### PR DESCRIPTION
![Screenshot 2020-05-30 at 11 29 41 PM](https://user-images.githubusercontent.com/5940286/83333340-b1521580-a2d2-11ea-9fb9-17774b5a9a5c.png)


This is because of my user id is 1 😄 .

This particular MR gives a change which uses the max between no 2 to user id.
