### PR TITLE
Show  thumbs up icon for doc approved status on the left side view.

### DIFF
--- a/app/server/static/components/annotation.pug
+++ b/app/server/static/components/annotation.pug
@@ -73,7 +73,8 @@ div.columns(v-cloak="")
           href="#"
         )
           span.icon
-            i.fa.fa-check(v-show="annotations[index] && annotations[index].length")
+            i.fa.fa-thumbs-up(v-show="annotations[index] && docs[index].annotation_approver")
+            i.fa.fa-check(v-show="annotations[index] && annotations[index].length && !docs[index].annotation_approver")
           span.name {{ doc.text.slice(0, 60) }}...
 
   div.column.is-7.is-offset-1.message.hero.is-fullheight#message-pane


### PR DESCRIPTION
 - Display "Thumbs up" icon if the doc is approved.
 - Else, display "Check mark" if the doc has annotations.
 - Otherwise, display no icon.

See #280 for discussion.