### PR TITLE
Fix wrong document list in text classification, closes #887

### DIFF
--- a/frontend/components/containers/annotation/EntityItemBox.vue
+++ b/frontend/components/containers/annotation/EntityItemBox.vue
@@ -11,7 +11,7 @@
 </template>
 
 <script>
-import { mapActions, mapGetters, mapState } from 'vuex'
+import { mapActions, mapGetters, mapMutations, mapState } from 'vuex'
 import EntityItemBox from '~/components/organisms/annotation/EntityItemBox'
 
 export default {
@@ -29,6 +29,12 @@ export default {
   },
 
   created() {
+    this.updateSearchOptions({
+      offset: this.offset
+    })
+    this.getDocumentList({
+      projectId: this.$route.params.id
+    })
     this.getLabelList({
       projectId: this.$route.params.id
     })
@@ -37,6 +43,7 @@ export default {
   methods: {
     ...mapActions('labels', ['getLabelList']),
     ...mapActions('documents', ['getDocumentList', 'deleteAnnotation', 'updateAnnotation', 'addAnnotation']),
+    ...mapMutations('documents', ['updateSearchOptions']),
     removeEntity(annotationId) {
       const payload = {
         annotationId,

--- a/frontend/components/containers/annotation/Seq2seqContainer.vue
+++ b/frontend/components/containers/annotation/Seq2seqContainer.vue
@@ -20,7 +20,7 @@
 </template>
 
 <script>
-import { mapActions, mapState, mapGetters } from 'vuex'
+import { mapActions, mapState, mapMutations, mapGetters } from 'vuex'
 import Seq2seqBox from '~/components/organisms/annotation/Seq2seqBox'
 
 export default {
@@ -36,7 +36,17 @@ export default {
     }
   },
 
+  created() {
+    this.updateSearchOptions({
+      offset: this.offset
+    })
+    this.getDocumentList({
+      projectId: this.$route.params.id
+    })
+  },
+
   methods: {
+    ...mapMutations('documents', ['updateSearchOptions']),
     ...mapActions('documents', ['getDocumentList', 'deleteAnnotation', 'updateAnnotation', 'addAnnotation']),
     _deleteAnnotation(annotationId) {
       const payload = {

--- a/frontend/components/containers/annotation/TextClassification.vue
+++ b/frontend/components/containers/annotation/TextClassification.vue
@@ -20,7 +20,7 @@
 
 <script>
 import Vue from 'vue'
-import { mapActions, mapGetters, mapState } from 'vuex'
+import { mapActions, mapGetters, mapMutations, mapState } from 'vuex'
 import MultiClassClassification from '@/components/organisms/annotation/MultiClassClassification'
 Vue.use(require('vue-shortkey'))
 
@@ -33,6 +33,7 @@ export default {
     ...mapState('labels', ['items']),
     ...mapState('documents', ['loading']),
     ...mapGetters('documents', ['currentDoc']),
+    ...mapGetters('pagination', ['offset']),
     multiKeys() {
       const multiKeys = {}
       for (const item of this.items) {
@@ -46,6 +47,12 @@ export default {
   },
 
   created() {
+    this.updateSearchOptions({
+      offset: this.offset
+    })
+    this.getDocumentList({
+      projectId: this.$route.params.id
+    })
     this.getLabelList({
       projectId: this.$route.params.id
     })
@@ -54,6 +61,7 @@ export default {
   methods: {
     ...mapActions('labels', ['getLabelList']),
     ...mapActions('documents', ['getDocumentList', 'deleteAnnotation', 'updateAnnotation', 'addAnnotation']),
+    ...mapMutations('documents', ['updateSearchOptions']),
     removeLabel(annotationId) {
       const payload = {
         annotationId,


### PR DESCRIPTION
Refers to #887 
Also helps #804 (refresh annotation page become more stable)

It seems that removing getDocumentList() from Paginator and BottomNavigator released this bug. 
So I decided to insert a getDocumentList() in TextClassification.vue but also defined **the offset**.