### PR TITLE
Replace django-pyodbc-azure with django-mssql-backend

### DIFF
--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -9,10 +9,10 @@ django-cloud-browser==0.5.0
 django-cors-headers==3.1.1
 django-filter==2.0.0
 django-heroku==0.3.1
+django-mssql-backend==2.8.1
 django-webpack-loader==0.6.0
 django-widget-tweaks==1.4.2
 django-polymorphic==2.0.3
-django-pyodbc-azure==2.1.0.0
 django-rest-polymorphic==0.1.8
 djangorestframework==3.10
 djangorestframework-csv==2.1.0


### PR DESCRIPTION
closes #858 

Because django-pyodbc-azure is inactive:
- https://github.com/michiya/django-pyodbc-azure/pull/204#issuecomment-563248221