### PR TITLE
Allow annotator to update/delete other's annotations

### DIFF
--- a/app/api/views.py
+++ b/app/api/views.py
@@ -235,8 +235,15 @@ class AnnotationList(generics.ListCreateAPIView):
 
 class AnnotationDetail(generics.RetrieveUpdateDestroyAPIView):
     lookup_url_kwarg = 'annotation_id'
-    permission_classes = [IsAuthenticated & (((IsAnnotator & IsOwnAnnotation) | IsAnnotationApprover)  | IsProjectAdmin)]
     swagger_schema = None
+
+    def get_permissions(self):
+        project = get_object_or_404(Project, pk=self.kwargs['project_id'])
+        if project.collaborative_annotation:
+            self.permission_classes = [IsAuthenticated & IsInProjectOrAdmin]
+        else:
+            self.permission_classes = [IsAuthenticated & IsInProjectOrAdmin & IsOwnAnnotation]
+        return super().get_permissions()
 
     def get_serializer_class(self):
         project = get_object_or_404(Project, pk=self.kwargs['project_id'])


### PR DESCRIPTION
Now, if `share annotation` option is checked, all the roles can view/delete/update other's annotations.
Not realtime.

closes #705 
closes #629
closes #531 