### PR TITLE
Fix ApproveLabelsAPI not to show other's annotations if it's checked

### DIFF
--- a/app/api/serializers.py
+++ b/app/api/serializers.py
@@ -84,6 +84,13 @@ class DocumentSerializer(serializers.ModelSerializer):
         fields = ('id', 'text', 'annotations', 'meta', 'annotation_approver')
 
 
+class ApproverSerializer(DocumentSerializer):
+
+    class Meta:
+        model = Document
+        fields = ('id', 'annotation_approver')
+
+
 class ProjectSerializer(serializers.ModelSerializer):
     current_users_role = serializers.SerializerMethodField()
 

--- a/app/api/views.py
+++ b/app/api/views.py
@@ -20,7 +20,7 @@ from rest_framework_csv.renderers import CSVRenderer
 from .filters import DocumentFilter
 from .models import Project, Label, Document, RoleMapping, Role
 from .permissions import IsProjectAdmin, IsAnnotatorAndReadOnly, IsAnnotator, IsAnnotationApproverAndReadOnly, IsOwnAnnotation, IsAnnotationApprover
-from .serializers import ProjectSerializer, LabelSerializer, DocumentSerializer, UserSerializer
+from .serializers import ProjectSerializer, LabelSerializer, DocumentSerializer, UserSerializer, ApproverSerializer
 from .serializers import ProjectPolymorphicSerializer, RoleMappingSerializer, RoleSerializer
 from .utils import CSVParser, ExcelParser, JSONParser, PlainTextParser, CoNLLParser, AudioParser, iterable_to_io
 from .utils import JSONLRenderer
@@ -133,7 +133,7 @@ class ApproveLabelsAPI(APIView):
         document = get_object_or_404(Document, pk=self.kwargs['doc_id'])
         document.annotations_approved_by = self.request.user if approved else None
         document.save()
-        return Response(DocumentSerializer(document).data)
+        return Response(ApproverSerializer(document).data)
 
 
 class LabelList(generics.ListCreateAPIView):


### PR DESCRIPTION
closes #481 
![](https://gyazo.com/e84d8ac8bf69d706fa6b9b3c7c881208/raw)

This is a temporary solution. My thought:
https://github.com/doccano/doccano/issues/531#issuecomment-662185044