### PR TITLE
Adding keyboard shortcut for approval button

### DIFF
--- a/frontend/components/containers/annotation/ApproveButton.vue
+++ b/frontend/components/containers/annotation/ApproveButton.vue
@@ -2,7 +2,7 @@
   <v-tooltip bottom>
     <template v-slot:activator="{ on }">
       <v-btn
-        v-shortkey.once="['a']"
+        v-shortkey.once="['enter']"
         :disabled="disabled"
         class="text-capitalize ps-1 pe-1"
         min-width="36"

--- a/frontend/components/containers/annotation/ApproveButton.vue
+++ b/frontend/components/containers/annotation/ApproveButton.vue
@@ -2,11 +2,13 @@
   <v-tooltip bottom>
     <template v-slot:activator="{ on }">
       <v-btn
+        v-shortkey.once="['a']"
         :disabled="disabled"
         class="text-capitalize ps-1 pe-1"
         min-width="36"
         outlined
         v-on="on"
+        @shortkey="approveNextPage"
         @click="approveDocument"
       >
         <v-icon v-if="approved">
@@ -35,6 +37,16 @@ export default {
     disabled: {
       type: Boolean,
       default: false
+    },
+    value: {
+      type: Number,
+      default: 1,
+      required: true
+    },
+    length: {
+      type: Number,
+      default: 1,
+      required: true
     }
   },
 
@@ -44,6 +56,12 @@ export default {
       this.approve({
         projectId: this.$route.params.id
       })
+    },
+    /** Approves document and moves to the next page */
+    approveNextPage() {
+      const page = Math.min(this.value + 1, this.length)
+      this.$emit('input', page)
+      this.approveDocument()
     }
   }
 }

--- a/frontend/layouts/annotation.vue
+++ b/frontend/layouts/annotation.vue
@@ -30,6 +30,8 @@
           <v-col>
             <approve-button
               v-if="canViewApproveButton"
+              v-model="page"
+              :length="total"
               :approved="approved"
               :disabled="currentDoc ? false : true"
             />


### PR DESCRIPTION
Addressing issue #718

When user presses the ‘a’ key, the document toggles from ‘approved’ to ‘not approved’ or vice versa. The user is advanced to the next item in the queue once the key is pressed.