### PR TITLE
Bring both run.sh scripts to parity

### DIFF
--- a/app/tools/run.sh
+++ b/app/tools/run.sh
@@ -3,13 +3,14 @@
 set -o errexit
 
 echo "Making staticfiles"
-python manage.py collectstatic --noinput
+if [[ ! -d "staticfiles" ]]; then python manage.py collectstatic --noinput; fi
 
 echo "Initializing database"
 python manage.py wait_for_db
 python manage.py migrate
 python manage.py create_roles
 
+echo "Creating admin"
 if [[ -n "${ADMIN_USERNAME}" ]] && [[ -n "${ADMIN_PASSWORD}" ]] && [[ -n "${ADMIN_EMAIL}" ]]; then
   python manage.py create_admin \
     --username "${ADMIN_USERNAME}" \
@@ -20,4 +21,5 @@ if [[ -n "${ADMIN_USERNAME}" ]] && [[ -n "${ADMIN_PASSWORD}" ]] && [[ -n "${ADMI
 fi
 
 echo "Starting django"
-gunicorn --bind 0.0.0.0:8000 app.wsgi --timeout 300
+gunicorn --bind="0.0.0.0:${PORT:-8000}" --workers="${WORKERS:-1}" app.wsgi --timeout 300
+

--- a/tools/run.sh
+++ b/tools/run.sh
@@ -2,14 +2,23 @@
 
 set -o errexit
 
+echo "Making staticfiles"
 if [[ ! -d "app/staticfiles" ]]; then python app/manage.py collectstatic --noinput; fi
 
+echo "Initializing database"
 python app/manage.py wait_for_db
 python app/manage.py migrate
 python app/manage.py create_roles
 
-if [[ -n "${ADMIN_USERNAME}" ]] && [[ -n "${ADMIN_EMAIL}" ]] && [[ -n "${ADMIN_PASSWORD}" ]]; then
-  python app/manage.py create_admin --noinput --username="${ADMIN_USERNAME}" --email="${ADMIN_EMAIL}" --password="${ADMIN_PASSWORD}"
+echo "Creating admin"
+if [[ -n "${ADMIN_USERNAME}" ]] && [[ -n "${ADMIN_PASSWORD}" ]] && [[ -n "${ADMIN_EMAIL}" ]]; then
+  python app/manage.py create_admin \
+    --username "${ADMIN_USERNAME}" \
+    --password "${ADMIN_PASSWORD}" \
+    --email "${ADMIN_EMAIL}" \
+    --noinput \
+  || true
 fi
 
+echo "Starting django"
 gunicorn --bind="0.0.0.0:${PORT:-8000}" --workers="${WORKERS:-1}" --pythonpath=app app.wsgi --timeout 300


### PR DESCRIPTION
Noticed that the shell script `tools/run.sh` didn't include some echo statements and the workaround (`|| true`) for cases when the admin user exists, both of which exist in `app/tools/run.sh`.

This PR brings them both to parity.

Fixes #965.