### PR TITLE
Clear text in label selector after typing, fix #942

### DIFF
--- a/frontend/components/organisms/annotation/MultiClassClassification.vue
+++ b/frontend/components/organisms/annotation/MultiClassClassification.vue
@@ -7,6 +7,8 @@
     hide-selected
     chips
     multiple
+    :search-input.sync="search"
+    @change="search=''"
   >
     <template v-slot:selection="{ attrs, item, select, selected }">
       <v-chip
@@ -48,6 +50,12 @@ export default {
       type: Function,
       default: () => ([]),
       required: true
+    }
+  },
+
+  data() {
+    return {
+      search: ''
     }
   },
 


### PR DESCRIPTION
fix #942

I can't reproduce the 400 error so I only fixed the reset of the text.

![](https://i.gyazo.com/9a090829283bd2125c16d214d89f92a4.gif)