### PR TITLE
Revert "Bump highlight.js from 9.12.0 to 10.1.2 in /app/server/static"

### DIFF
--- a/app/server/static/package-lock.json
+++ b/app/server/static/package-lock.json
@@ -4015,9 +4015,9 @@
       "dev": true
     },
     "highlight.js": {
-      "version": "10.1.2",
-      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.1.2.tgz",
-      "integrity": "sha512-Q39v/Mn5mfBlMff9r+zzA+gWxRsCRKwEMvYTiisLr/XUiFI/4puWt0Ojdko3R3JCNWGdOWaA5g/Yxqa23kC5AA=="
+      "version": "9.12.0",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-9.12.0.tgz",
+      "integrity": "sha1-5tnb5Xy+/mB1HwKvM2GVhwyQwB4="
     },
     "hmac-drbg": {
       "version": "1.0.1",

--- a/app/server/static/package.json
+++ b/app/server/static/package.json
@@ -18,7 +18,7 @@
     "axios-mock-adapter": "^1.17.0",
     "buefy": "^0.8.2",
     "chart.js": "^2.7.2",
-    "highlight.js": "^10.1.2",
+    "highlight.js": "^9.12.0",
     "lodash.isempty": "^4.4.0",
     "marked": "^0.7.0",
     "swiper": "^4.3.3",


### PR DESCRIPTION
Reverts doccano/doccano#1066
fix #1074 
fix #1083 