### PR TITLE
Support pip Installation

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -1,0 +1,47 @@
+name: Upload Python Package
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    
+    steps:
+    - uses: actions/checkout@v2
+    - name: Preparation
+      run: |
+        mkdir app/client
+        cp README.md app/README.md
+    - name: Use Node.js
+      uses: actions/setup-node@v1
+      with:
+        node-version: '12.x'
+    - name: Build with Node.js
+      run: |
+        yarn install
+        yarn build
+        cp -r dist ../app/client/
+      working-directory: ./frontend
+    - name: Setup Python 3.8
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.8
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install setuptools wheel
+        pip install -r requirements.txt
+    - name: collectstatic
+      run: |
+        python manage.py collectstatic --noinput
+      working-directory: ./app
+    - name: Build a binary wheel and a source tarball
+      run: |
+        python setup.py sdist bdist_wheel
+    - name: Publish a Python distribution to PyPI
+      uses: pypa/gh-action-pypi-publish@master
+      with:
+        user: ${{ secrets.PYPI_USERNAME }}
+        password: ${{ secrets.PYPI_PASSWORD }}

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -7,13 +7,12 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
-    
+
     steps:
     - uses: actions/checkout@v2
     - name: Preparation
       run: |
         mkdir app/client
-        cp README.md app/README.md
     - name: Use Node.js
       uses: actions/setup-node@v1
       with:
@@ -24,6 +23,8 @@ jobs:
         yarn build
         cp -r dist ../app/client/
       working-directory: ./frontend
+      env:
+        PUBLIC_PATH: "/static/_nuxt/"
     - name: Setup Python 3.8
       uses: actions/setup-python@v2
       with:

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,7 @@
+include app/manage.py
+include app/requirements.txt
+include README.md
+graft app/staticfiles
+graft app/client
+graft app/doccano
+global-exclude *.pyc

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,7 +1,19 @@
 include app/manage.py
 include app/requirements.txt
 include README.md
+exclude *.yml
+exclude *.yaml
+
 graft app/staticfiles
 graft app/client
 graft app/doccano
+
+prune app/staticfiles/bundle
+prune app/staticfiles/assets
+prune app/staticfiles/components
+prune app/server/static
+prune frontend
+prune docs
+prune nginx
+prune tools
 global-exclude *.pyc

--- a/README.md
+++ b/README.md
@@ -26,28 +26,67 @@ You can try the [annotation demo](http://doccano.herokuapp.com).
 
 ## Usage
 
-Two options to run doccano:
+Three options to run doccano:
 
-- production,
-- development.
+- pip(experimental)
+- Docker
+- Docker Compose
+  - production
+  - development
 
-To use doccano, please follow:
+For docker and docker compose, you need to install dependencies:
 
-### Install dependencies
+- [Git](https://git-scm.com)
+- [Docker](https://www.docker.com)
+- [Docker Compose](https://docs.docker.com/compose)
 
-You need to install dependencies:
+### pip installation
 
-- [Git](https://git-scm.com),
-- [Docker](https://www.docker.com),
-- [Docker Compose](https://docs.docker.com/compose).
+To install doccano, simply run:
 
-### Get the code
+```bash
+pip install doccano
+```
+
+After installation, simply run the following command:
+
+```bash
+doccano
+```
+
+Go to <http://0.0.0.0:{YOUR_PORT}/>.
+
+### Docker
+
+As a one-time setup, create a Docker container as follows:
+
+```bash
+docker pull doccano/doccano
+docker container create --name doccano \
+  -e "ADMIN_USERNAME=admin" \
+  -e "ADMIN_EMAIL=admin@example.com" \
+  -e "ADMIN_PASSWORD=password" \
+  -p 8000:8000 doccano/doccano
+```
+
+Next, start doccano by running the container:
+
+```bash
+docker container start doccano
+```
+
+To stop the container, run `docker container stop doccano -t 5`.
+All data created in the container will persist across restarts.
+
+Go to <http://127.0.0.1:8000/>.
+
+### Docker Compose
 
 You need to clone the repository:
 
 ```bash
-$ git clone https://github.com/doccano/doccano.git
-$ cd doccano
+git clone https://github.com/doccano/doccano.git
+cd doccano
 ```
 
 _Note for Windows developers:_ Be sure to configure git to correctly handle line endings or you may encounter `status code 127` errors while running the services in future steps. Running with the git config options below will ensure your git directory correctly handles line endings.
@@ -56,7 +95,7 @@ _Note for Windows developers:_ Be sure to configure git to correctly handle line
 git clone https://github.com/doccano/doccano.git --config core.autocrlf=input
 ```
 
-### Production
+#### Production
 
 Set the superuser account credentials in the `docker-compose.prod.yml` file:
 
@@ -79,35 +118,7 @@ $ docker-compose -f docker-compose.prod.yml up
 
 Go to <http://0.0.0.0/>.
 
-<!--
-
-### Docker
-
-As a one-time setup, create a Docker container for Doccano:
-
-```bash
-docker pull doccano/doccano
-docker container create --name doccano \
-  -e "ADMIN_USERNAME=admin" \
-  -e "ADMIN_EMAIL=admin@example.com" \
-  -e "ADMIN_PASSWORD=password" \
-  -p 8000:8000 doccano/doccano
-```
-
-Next, start Doccano by running the container:
-
-```bash
-docker container start doccano
-```
-
-To stop the container, run `docker container stop doccano -t 5`.
-All data created in the container will persist across restarts.
-
-Go to <http://127.0.0.1:8000/>.
-
--->
-
-### Development
+#### Development
 
 Set the superuser account credentials in the `docker-compose.dev.yml` file:
 

--- a/app/MANIFEST.in
+++ b/app/MANIFEST.in
@@ -1,0 +1,7 @@
+include manage.py
+include requirements.txt
+include README.md
+graft staticfiles
+graft client
+graft doccano
+global-exclude *.pyc

--- a/app/MANIFEST.in
+++ b/app/MANIFEST.in
@@ -1,7 +1,0 @@
-include manage.py
-include requirements.txt
-include README.md
-graft staticfiles
-graft client
-graft doccano
-global-exclude *.pyc

--- a/app/doccano/doccano.py
+++ b/app/doccano/doccano.py
@@ -1,0 +1,44 @@
+import argparse
+import os
+import subprocess
+
+
+def main():
+    parser = argparse.ArgumentParser(prog='gfg', description='GfG article demo package.')
+    parser.add_argument('--username', type=str, default='admin')
+    parser.add_argument('--password', type=str, default='password')
+    parser.add_argument('--email', type=str, default='example@example.com')
+    parser.add_argument('--port', type=int, default=8000)
+    parser.add_argument('--workers', type=int, default=1)
+    args = parser.parse_args()
+
+    print('Create staticfiles.')
+    # subprocess.call(['python', 'manage.py', 'collectstatic', '--noinput'], shell=False)
+
+    print('Setup databse.')
+    base = os.path.abspath(os.path.dirname(os.path.dirname(__file__)))
+    #base = os.path.abspath(os.path.dirname(__file__))
+    # manage_path = os.path.join(base, 'app/manage.py')
+    manage_path = os.path.join(base, 'manage.py')
+    print(manage_path)
+    subprocess.call(['python', manage_path, 'wait_for_db'], shell=False)
+    subprocess.call(['python', manage_path, 'migrate'], shell=False)
+    subprocess.call(['python', manage_path, 'create_roles'], shell=False)
+
+    print('Create admin user.')
+    subprocess.call(['python', manage_path, 'create_admin',
+                     '--username', args.username,
+                     '--password', args.password,
+                     '--email', args.email,
+                     '--noinput'], shell=False)
+
+    print(f'Starting server with port {args.port}.')
+    subprocess.call(['gunicorn',
+                     '--bind', f'0.0.0.0:{args.port}',
+                     '--workers', str(args.workers),
+                     'app.wsgi',
+                     '--timeout', '300'], shell=False)
+
+
+if __name__ == '__main__':
+    main()

--- a/app/doccano/doccano.py
+++ b/app/doccano/doccano.py
@@ -4,13 +4,17 @@ import subprocess
 
 
 def main():
-    parser = argparse.ArgumentParser(prog='gfg', description='GfG article demo package.')
-    parser.add_argument('--username', type=str, default='admin')
-    parser.add_argument('--password', type=str, default='password')
-    parser.add_argument('--email', type=str, default='example@example.com')
-    parser.add_argument('--port', type=int, default=8000)
-    parser.add_argument('--workers', type=int, default=1)
+    parser = argparse.ArgumentParser(description='doccano.')
+    parser.add_argument('--username', type=str, default='admin', help='admin username')
+    parser.add_argument('--password', type=str, default='password', help='admin password')
+    parser.add_argument('--email', type=str, default='example@example.com', help='admin email')
+    parser.add_argument('--port', type=int, default=8000, help='port')
+    parser.add_argument('--workers', type=int, default=1, help='workers')
+    parser.add_argument('--database_url', type=str, default='sqlite:///doccano.db', help='data store')
     args = parser.parse_args()
+
+    os.environ.setdefault('DEBUG', 'False')
+    os.environ.setdefault('DATABASE_URL', args.database_url)
 
     print('Setup Database.')
     base = os.path.abspath(os.path.dirname(os.path.dirname(__file__)))
@@ -27,7 +31,6 @@ def main():
                      '--noinput'], shell=False)
 
     print(f'Starting server with port {args.port}.')
-    os.environ['DEBUG'] = 'False'
     subprocess.call(['python', manage_path, 'runserver', f'0.0.0.0:{args.port}'])
 
 

--- a/app/doccano/doccano.py
+++ b/app/doccano/doccano.py
@@ -12,15 +12,9 @@ def main():
     parser.add_argument('--workers', type=int, default=1)
     args = parser.parse_args()
 
-    print('Create staticfiles.')
-    # subprocess.call(['python', 'manage.py', 'collectstatic', '--noinput'], shell=False)
-
-    print('Setup databse.')
+    print('Setup Database.')
     base = os.path.abspath(os.path.dirname(os.path.dirname(__file__)))
-    #base = os.path.abspath(os.path.dirname(__file__))
-    # manage_path = os.path.join(base, 'app/manage.py')
     manage_path = os.path.join(base, 'manage.py')
-    print(manage_path)
     subprocess.call(['python', manage_path, 'wait_for_db'], shell=False)
     subprocess.call(['python', manage_path, 'migrate'], shell=False)
     subprocess.call(['python', manage_path, 'create_roles'], shell=False)
@@ -33,11 +27,8 @@ def main():
                      '--noinput'], shell=False)
 
     print(f'Starting server with port {args.port}.')
-    subprocess.call(['gunicorn',
-                     '--bind', f'0.0.0.0:{args.port}',
-                     '--workers', str(args.workers),
-                     'app.wsgi',
-                     '--timeout', '300'], shell=False)
+    os.environ['DEBUG'] = 'False'
+    subprocess.call(['python', manage_path, 'runserver', f'0.0.0.0:{args.port}'])
 
 
 if __name__ == '__main__':

--- a/app/setup.py
+++ b/app/setup.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+import io
+import os
+import sys
+
+from setuptools import find_packages, setup
+
+NAME = 'doccano'
+DESCRIPTION = 'doccano'
+URL = 'https://github.com/doccano/doccano'
+EMAIL = 'hiroki.nakayama.py@gmail.com'
+AUTHOR = 'Hironsan'
+LICENSE = 'MIT'
+
+here = os.path.abspath(os.path.dirname(__file__))
+with io.open(os.path.join(here, 'README.md'), encoding='utf-8') as f:
+    long_description = '\n' + f.read()
+
+if sys.argv[-1] == 'publish':
+    os.system('python setup.py sdist bdist_wheel upload')
+    sys.exit()
+
+# required = ['requests', 'boto3', 'pydantic', 'jinja2']
+required = [line.rstrip() for line in io.open(os.path.join(here, 'requirements.txt')) if not line.startswith('psy')]
+
+setup(
+    name=NAME,
+    use_scm_version={'root': '..'},
+    setup_requires=['setuptools_scm'],
+    description=DESCRIPTION,
+    long_description=long_description,
+    long_description_content_type='text/markdown',
+    author=AUTHOR,
+    author_email=EMAIL,
+    url=URL,
+    packages=find_packages(exclude=('*.tests',)),
+    entry_points={
+        'console_scripts': [
+            'doccano = doccano.doccano:main'
+        ]
+    },
+    install_requires=required,
+    include_package_data=True,
+    license=LICENSE,
+    classifiers=[
+        'License :: OSI Approved :: MIT License',
+        'Programming Language :: Python',
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: Implementation :: CPython',
+        'Programming Language :: Python :: Implementation :: PyPy'
+    ],
+)

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 import io
 import os
-import sys
 
 from setuptools import find_packages, setup
 
@@ -17,16 +16,12 @@ here = os.path.abspath(os.path.dirname(__file__))
 with io.open(os.path.join(here, 'README.md'), encoding='utf-8') as f:
     long_description = '\n' + f.read()
 
-if sys.argv[-1] == 'publish':
-    os.system('python setup.py sdist bdist_wheel upload')
-    sys.exit()
-
 # required = ['requests', 'boto3', 'pydantic', 'jinja2']
-required = [line.rstrip() for line in io.open(os.path.join(here, 'requirements.txt')) if not line.startswith('psy')]
+required = [line.rstrip() for line in io.open(os.path.join(here, 'app/requirements.txt')) if not line.startswith('psy')]
 
 setup(
     name=NAME,
-    use_scm_version={'root': '..'},
+    use_scm_version=True,
     setup_requires=['setuptools_scm'],
     description=DESCRIPTION,
     long_description=long_description,
@@ -37,7 +32,7 @@ setup(
     packages=find_packages(exclude=('*.tests',)),
     entry_points={
         'console_scripts': [
-            'doccano = doccano.doccano:main'
+            'doccano = app.doccano.doccano:main'
         ]
     },
     install_requires=required,


### PR DESCRIPTION
To make doccano easy to use, this PR supports pip installation and allow doccano to run as a command line tool:

```bash
❯ pip install doccano
❯ doccano --port=8000
Starting server with port 8000.
[2020-12-04 12:00:26 +0900] [8255] [INFO] Starting gunicorn 19.9.0
[2020-12-04 12:00:26 +0900] [8255] [INFO] Listening at: http://0.0.0.0:8000 (8255)
[2020-12-04 12:00:26 +0900] [8255] [INFO] Using worker: sync
[2020-12-04 12:00:26 +0900] [8257] [INFO] Booting worker with pid: 8257
```

This is an experimental feature. The performance is not good because of using the development server.