### PR TITLE
fix python3 compatibility problem

### DIFF
--- a/app/doccano/doccano.py
+++ b/app/doccano/doccano.py
@@ -1,5 +1,6 @@
 import argparse
 import os
+import sys
 import subprocess
 
 
@@ -19,19 +20,19 @@ def main():
     print('Setup Database.')
     base = os.path.abspath(os.path.dirname(os.path.dirname(__file__)))
     manage_path = os.path.join(base, 'manage.py')
-    subprocess.call(['python', manage_path, 'wait_for_db'], shell=False)
-    subprocess.call(['python', manage_path, 'migrate'], shell=False)
-    subprocess.call(['python', manage_path, 'create_roles'], shell=False)
+    subprocess.call([sys.executable, manage_path, 'wait_for_db'], shell=False)
+    subprocess.call([sys.executable, manage_path, 'migrate'], shell=False)
+    subprocess.call([sys.executable, manage_path, 'create_roles'], shell=False)
 
     print('Create admin user.')
-    subprocess.call(['python', manage_path, 'create_admin',
+    subprocess.call([sys.executable, manage_path, 'create_admin',
                      '--username', args.username,
                      '--password', args.password,
                      '--email', args.email,
                      '--noinput'], shell=False)
 
     print(f'Starting server with port {args.port}.')
-    subprocess.call(['python', manage_path, 'runserver', f'0.0.0.0:{args.port}'])
+    subprocess.call([sys.executable, manage_path, 'runserver', f'0.0.0.0:{args.port}'])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This is PR improved the python3 compatibility problem. Previously, it calls the python executable in the environment. This could be troublesome since many linux system has python2 as default executable in the environment, but the user might installed the python3 version of the package.

Changing 'python' to sys.executable would force the executable for django to be the same as doccano.