### PR TITLE
Changed "doccano webserver -p" argument to "--port"

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ doccano init
 # Create a super user.
 doccano createuser --username admin --password pass
 # Start the webserver.
-doccano webserver -p 8000
+doccano webserver --port 8000
 ```
 
 And in another terminal, run the following command:


### PR DESCRIPTION
See diffs. This md file goes through the setup process using pip. However, it says to use `doccano webserver -p 8000`, but the parameter -p is not valid. You must use --port instead. That's what I have changed.