### PR TITLE
fix download dataset problems

### DIFF
--- a/backend/api/views/download/writer.py
+++ b/backend/api/views/download/writer.py
@@ -136,7 +136,7 @@ class JSONLWriter(LineWriter):
             'data': record.data,
             'label': record.label,
             **record.metadata
-        },ensure_ascii=False)
+        }, ensure_ascii=False)
 
 
 class FastTextWriter(LineWriter):


### PR DESCRIPTION
download dataset to a csv file, but I get an empty file in zip
download json file or jsonL file contains chinese, it shows \uxxxx but not chinese