### PR TITLE
Remove unneeded builder call

### DIFF
--- a/backend/api/views/auto_labeling.py
+++ b/backend/api/views/auto_labeling.py
@@ -121,8 +121,7 @@ class AutoLabelingConfigParameterTest(APIView):
                 'You need to correctly specify the required fields: {}'.format(required_fields)
             )
         try:
-            request = model.build()
-            response = request.send(text=sample_text)
+            response = model.send(text=sample_text)
             return Response(response, status=status.HTTP_200_OK)
         except requests.exceptions.ConnectionError:
             raise URLConnectionError


### PR DESCRIPTION
This a PR to fix part of the issues from #1307, which caused failures when trying to create Custom REST Request models.