### PR TITLE
put variables to .env file

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ GOOGLE_TRACKING_ID: "UA-12345678-1"
 Run doccano:
 
 ```bash
-$ docker-compose -f docker-compose.prod.yml up
+$ docker-compose -f docker-compose.prod.yml --env-file ./config/.env.example up
 ```
 
 Go to <http://0.0.0.0/>.
@@ -142,7 +142,7 @@ ADMIN_PASSWORD: "password"
 Run Doccano:
 
 ```bash
-$ docker-compose -f docker-compose.dev.yml up
+$ docker-compose -f docker-compose.dev.yml --env-file ./config/.env.example up
 ```
 
 Go to <http://127.0.0.1:3000/>.

--- a/config/.env.example
+++ b/config/.env.example
@@ -1,0 +1,14 @@
+# platform settings
+ADMIN_USERNAME=admin
+ADMIN_PASSWORD=password
+ADMIN_EMAIL=admin@example.com
+
+
+# rabbit mq settings
+RABBITMQ_DEFAULT_USER=doccano
+RABBITMQ_DEFAULT_PASS=doccano
+
+# database settings
+POSTGRES_USER=doccano
+POSTGRES_PASSWORD=doccano
+POSTGRES_DB=doccano

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -9,11 +9,11 @@ services:
       - .:/src
       - venv:/root/.local/share
     environment:
-      ADMIN_USERNAME: "admin"
-      ADMIN_PASSWORD: "password"
-      ADMIN_EMAIL: "admin@example.com"
-      CELERY_BROKER_URL: "amqp://doccano:doccano@rabbitmq"
-      DATABASE_URL: "postgres://doccano:doccano@postgres:5432/doccano?sslmode=disable"
+      ADMIN_USERNAME: "${ADMIN_USERNAME}"
+      ADMIN_PASSWORD: "${ADMIN_PASSWORD}"
+      ADMIN_EMAIL: ${ADMIN_EMAIL}
+      CELERY_BROKER_URL: "amqp://${RABBITMQ_DEFAULT_USER}:${RABBITMQ_DEFAULT_PASS}@rabbitmq"
+      DATABASE_URL: "postgres://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB}?sslmode=disable"
       ALLOW_SIGNUP: "False"
       DEBUG: "True"
     ports:
@@ -34,8 +34,8 @@ services:
     entrypoint: ["/src/tools/dev-celery.sh"]
     environment:
       PYTHONUNBUFFERED: "1"
-      CELERY_BROKER_URL: "amqp://doccano:doccano@rabbitmq"
-      DATABASE_URL: "postgres://doccano:doccano@postgres:5432/doccano?sslmode=disable"
+      CELERY_BROKER_URL: "amqp://${RABBITMQ_DEFAULT_USER}:${RABBITMQ_DEFAULT_PASS}@rabbitmq"
+      DATABASE_URL: "postgres://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB}?sslmode=disable"
     depends_on:
       - postgres
       - rabbitmq
@@ -45,8 +45,8 @@ services:
   rabbitmq:
     image: rabbitmq:3.8
     environment:
-      RABBITMQ_DEFAULT_USER: "doccano"
-      RABBITMQ_DEFAULT_PASS: "doccano"
+      RABBITMQ_DEFAULT_USER: "${RABBITMQ_DEFAULT_USER}"
+      RABBITMQ_DEFAULT_PASS: "${RABBITMQ_DEFAULT_PASS}"
     ports:
       - 5672:5672
     networks:
@@ -73,9 +73,9 @@ services:
     volumes:
       - postgres_data:/var/lib/postgresql/data/
     environment:
-      POSTGRES_USER: "doccano"
-      POSTGRES_PASSWORD: "doccano"
-      POSTGRES_DB: "doccano"
+      POSTGRES_USER: "${POSTGRES_USER}"
+      POSTGRES_PASSWORD: "${POSTGRES_PASSWORD}"
+      POSTGRES_DB: "${POSTGRES_DB}"
     networks:
       - network-backend
 

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -9,11 +9,11 @@ services:
       - static_volume:/backend/staticfiles
       - media:/backend/media
     environment:
-      ADMIN_USERNAME: "admin"
-      ADMIN_PASSWORD: "password"
-      ADMIN_EMAIL: "admin@example.com"
-      CELERY_BROKER_URL: "amqp://doccano:doccano@rabbitmq"
-      DATABASE_URL: "postgres://doccano:doccano@postgres:5432/doccano?sslmode=disable"
+      ADMIN_USERNAME: "${ADMIN_USERNAME}"
+      ADMIN_PASSWORD: "${ADMIN_PASSWORD}"
+      ADMIN_EMAIL: ${ADMIN_EMAIL}
+      CELERY_BROKER_URL: "amqp://${RABBITMQ_DEFAULT_USER}:${RABBITMQ_DEFAULT_PASS}@rabbitmq"
+      DATABASE_URL: "postgres://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB}?sslmode=disable"
       ALLOW_SIGNUP: "False"
       DEBUG: "False"
     depends_on:
@@ -31,8 +31,8 @@ services:
     entrypoint: ["/opt/bin/prod-celery.sh"]
     environment:
       PYTHONUNBUFFERED: "1"
-      CELERY_BROKER_URL: "amqp://doccano:doccano@rabbitmq"
-      DATABASE_URL: "postgres://doccano:doccano@postgres:5432/doccano?sslmode=disable"
+      CELERY_BROKER_URL: "amqp://${RABBITMQ_DEFAULT_USER}:${RABBITMQ_DEFAULT_PASS}@rabbitmq"
+      DATABASE_URL: "postgres://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB}?sslmode=disable"
     depends_on:
       - postgres
       - rabbitmq
@@ -42,8 +42,8 @@ services:
   rabbitmq:
     image: rabbitmq:3.8
     environment:
-      RABBITMQ_DEFAULT_USER: "doccano"
-      RABBITMQ_DEFAULT_PASS: "doccano"
+      RABBITMQ_DEFAULT_USER: "${RABBITMQ_DEFAULT_USER}"
+      RABBITMQ_DEFAULT_PASS: "${RABBITMQ_DEFAULT_PASS}"
     ports:
       - 5672:5672
     networks:
@@ -71,9 +71,9 @@ services:
     volumes:
       - postgres_data:/var/lib/postgresql/data/
     environment:
-      POSTGRES_USER: "doccano"
-      POSTGRES_PASSWORD: "doccano"
-      POSTGRES_DB: "doccano"
+      POSTGRES_USER: "${POSTGRES_USER}"
+      POSTGRES_PASSWORD: "${POSTGRES_PASSWORD}"
+      POSTGRES_DB: "${POSTGRES_DB}"
     networks:
       - network-backend
 


### PR DESCRIPTION
I think it would be more convenient regarding git updates to extract the config variables from docker-compose files into an .env file as demonstrated in the [docker documentation](https://docs.docker.com/compose/environment-variables/).