### PR TITLE
support image display and url handling

### DIFF
--- a/frontend/components/tasks/metadata/ListMetadata.vue
+++ b/frontend/components/tasks/metadata/ListMetadata.vue
@@ -7,7 +7,19 @@
     :no-data-text="$t('vuetify.noDataAvailable')"
     disable-pagination
     class="elevation-1"
-  />
+  >
+    <template v-slot:item.value="{ item }">
+      <template v-if="item.key.indexOf('im_url') > -1">
+        <a :href="item.value" target="_blank"><img :src="item.value" style="height: 250px" /></a>
+      </template>
+      <template v-else-if="item.key.indexOf('url') > -1">
+        <a :href="item.value" target="_blank">{{ item.value }}</a>
+      </template>
+      <template v-else>
+        {{ item.value }}
+      </template>
+    </template>
+  </v-data-table>
 </template>
 
 <script lang="ts">


### PR DESCRIPTION
feature_request from [issue-1067](https://github.com/doccano/doccano/issues/1067)
- display image when the key is `"im_url"`, for example: `"im_url": "http://media-prod.oxfam.org.uk/images/products/HighStDonated/Main/HD_101670797_01.jpg"`
- create a link when the key contains string `"url"`, for example: `"product_url"`. (since the logic is to always handle `"im_url"` first, thus even though `"im_url"` also contains string `"url"`, it won't be handled here)

You can try out using these jsonl:
```json
{"text": "[title] Drownproofing\n[desc] Describes a survival technique designed to keep you afloat indefinitely (well, at least until you grow old and die of natural causes). With this concept of water safety anyone - young or old or even the non-swimmer can be virtually insured against drowning", "product_url": "http://www.oxfam.org.uk/shop/product/HD_101670797", "im_url": "http://media-prod.oxfam.org.uk/images/products/HighStDonated/Main/HD_101670797_01.jpg", "category": "Entertainment_Books_Books", "label": [[8, 21, "book_movie"]]}
{"text": "[title] Argentium Silver Mens Wedding Band\n[desc] 9ct gold-plated Argentium Silver 5mm Plain Cushion Court Wedding Band.", "product_url": "https://www.jdwilliams.co.uk/shop/Argentium-Silver-Mens-Wedding-Band/AH551/product/details/show.action?pdBoUid=3010#colour:,size:T", "im_url": "https://productimages.drct2u.com/mobile_huge_x2/products/ah/ah551/n16ah551500c.jpg", "category": "Rings", "label": [[30, 42, "category"]]}
```

Result:
![image](https://user-images.githubusercontent.com/15652756/124116388-7e63ed80-daa1-11eb-970c-2324c1beb1e9.png)
