### PR TITLE
Return a Response with a status if the task is not yet ready.

### DIFF
--- a/backend/api/views/export_dataset.py
+++ b/backend/api/views/export_dataset.py
@@ -32,6 +32,7 @@ class DownloadAPI(APIView):
         if ready:
             filename = task.result
             return FileResponse(open(filename, mode='rb'), as_attachment=True)
+        return Response({'status': 'Not ready'})
 
     def post(self, request, *args, **kwargs):
         project_id = self.kwargs['project_id']


### PR DESCRIPTION
Fix for #1439. Returns a simple JSON, to avoid a 500 error from the view. 