### PR TITLE
Remove unneeded query

### DIFF
--- a/backend/api/tasks.py
+++ b/backend/api/tasks.py
@@ -62,10 +62,8 @@ class DataFactory:
             self.data_class(project=project, **example.data)
             for example in examples
         ]
-        now = datetime.datetime.now()
-        self.data_class.objects.bulk_create(dataset)
-        ids = self.data_class.objects.filter(created_at__gte=now)
-        return list(ids)
+        results = self.data_class.objects.bulk_create(dataset)
+        return results
 
     def create_annotation(self, examples, ids, user, project):
         mapping = {label.text: label.id for label in project.labels.all()}


### PR DESCRIPTION
Bulk create returns the created objects in the same order as they have been added.

In Postgres, the query was wrong, because ordering was not guaranteed and sometimes it returned the ids in the wrong order than they were inserted.

This is a simpler fix for #1432, without requiring changes to the model. 