### PR TITLE
Increase the allowed max length for uploaded dataset filepath

### DIFF
--- a/backend/api/models.py
+++ b/backend/api/models.py
@@ -147,7 +147,7 @@ class Label(models.Model):
 
 class Example(models.Model):
     meta = models.JSONField(default=dict)
-    filename = models.FileField(default='.')
+    filename = models.FileField(default='.', max_length=1024)
     project = models.ForeignKey(
         to=Project,
         on_delete=models.CASCADE,


### PR DESCRIPTION
The default max_length for FileField is 100 characters and I think this is very limiting if we consider during the upload a random nested folder will be created.

This is an example on where the file actually located in the media folder:
<MEDIA_DIR>/TPBdmbMKMFgXf6e83qXPg2/PmTRJ4PmMngrBo8QmnqmBt/<FILENAME>
The length of the generated directory is 47 characters, which mean if we upload a file with length more than 53 characters it will cause error.

Note that generally the maximum length of a filename in UNIX system is 255 and the maximum length of a filepath is 4096 ([source](https://unix.stackexchange.com/questions/32795/what-is-the-maximum-allowed-filename-and-folder-size-with-ecryptfs)). Hence it will be good to relax the constraint of the FileField from 100 characters, in this PR we relax it into 1024 characters.

I believe this will resolve the issue: https://github.com/doccano/doccano/issues/1377