### PR TITLE
Display dataset page for all user

### DIFF
--- a/frontend/components/layout/TheSideBar.vue
+++ b/frontend/components/layout/TheSideBar.vue
@@ -73,7 +73,7 @@ export default {
           icon: 'mdi-database',
           text: this.$t('dataset.dataset'),
           link: 'dataset',
-          isVisible: this.role.is_project_admin
+          isVisible: true
         },
         {
           icon: 'label',

--- a/frontend/middleware/check-admin.js
+++ b/frontend/middleware/check-admin.js
@@ -9,7 +9,10 @@ export default _.debounce(async function({ app, store, route, redirect }) {
   const role = store.getters['projects/getCurrentUserRole']
   const projectRoot = app.localePath('/projects/' + route.params.id)
   const path = route.fullPath.replace(/\/$/g, '')
-  if (!role.is_project_admin && path !== projectRoot) {
-    return redirect(projectRoot)
+
+  if (role.is_project_admin || path === projectRoot || path.startsWith(projectRoot + '/dataset')) {
+    return
   }
+
+  return redirect(projectRoot)
 }, 1000)

--- a/frontend/pages/projects/_id/dataset/index.vue
+++ b/frontend/pages/projects/_id/dataset/index.vue
@@ -1,6 +1,6 @@
 <template>
   <v-card>
-    <v-card-title>
+    <v-card-title v-if="isProjectAdmin">
       <action-menu
         @upload="upload"
         @download="dialogDownload=true"
@@ -112,7 +112,8 @@ export default Vue.extend({
       project: {} as ProjectDTO,
       item: {} as ExampleListDTO,
       selected: [] as ExampleDTO[],
-      isLoading: false
+      isLoading: false,
+      isProjectAdmin: false
     }
   },
 
@@ -148,6 +149,7 @@ export default Vue.extend({
 
   async created() {
     this.project = await this.$services.project.findById(this.projectId)
+    this.isProjectAdmin = this.project.current_users_role.is_project_admin
   },
 
   methods: {


### PR DESCRIPTION
## Issue
https://github.com/doccano/doccano/issues/952

## What this PR do
- Allow dataset list page to be displayed not only for admin users but also for annotators and approvers.
- Hide the import, download, and delete action buttons except for admin.

## Screenshots
Annotator's screen

<img width="1011" alt="スクリーンショット 2021-09-27 2 35 57" src="https://user-images.githubusercontent.com/20487308/134830609-8b441c34-c2e3-4bdd-94fc-73a3f7832b02.png">

<img width="1009" alt="スクリーンショット 2021-09-27 2 36 07" src="https://user-images.githubusercontent.com/20487308/134830613-868c9157-6ce2-45df-aacb-8a6be06335d9.png">

## Next Actions
- Add a column to indicate the status of the annotation.