### PR TITLE
RTL support for sequence labeling projects

### DIFF
--- a/frontend/components/tasks/sequenceLabeling/EntityItemBox.vue
+++ b/frontend/components/tasks/sequenceLabeling/EntityItemBox.vue
@@ -210,8 +210,9 @@ export default {
     }
   },    
   beforeUpdate()  {
-    const arabic = /[\u0600-\u06FF]/;
-    if (arabic.test(this.text[0])) {
+    const arabicUnicodeRange = /[\u0600-\u06FF]/;
+    const hebrewUnicodeRange = /[\u0590-\u05FF]/;
+    if (arabicUnicodeRange.test(this.text[0]) || hebrewUnicodeRange.test(this.text[0])) {
       if (this.classes.includes("rtl")) {
         return;
       }

--- a/frontend/components/tasks/sequenceLabeling/EntityItemBox.vue
+++ b/frontend/components/tasks/sequenceLabeling/EntityItemBox.vue
@@ -1,6 +1,6 @@
 <template>
   <div id="connections-wrapper">
-    <div class="highlight-container highlight-container--bottom-labels" @click="open" @touchend="open">
+    <div :class="classes" @click="open" @touchend="open">
       <entity-item
           v-for="(chunk, i) in chunks"
           :key="i"
@@ -146,7 +146,8 @@ export default {
       x: 0,
       y: 0,
       start: 0,
-      end: 0
+      end: 0,
+      classes : ["highlight-container", "highlight-container--bottom-labels"]
     }
   },
 
@@ -207,8 +208,22 @@ export default {
       }
       return obj
     }
+  },    
+  beforeUpdate()  {
+    const arabic = /[\u0600-\u06FF]/;
+    if (arabic.test(this.text[0])) {
+      if (this.classes.includes("rtl")) {
+        return;
+      }
+      this.classes.push("rtl");
+    } 
+    else {
+      const index = this.classes.indexOf("rtl");
+      if (index > -1) {
+        this.classes.splice(index, 1);
+      }
+    }
   },
-
   updated() {
     this.$nextTick(() => {
       const parentPos = document.getElementById('connections-wrapper').getBoundingClientRect();
@@ -468,6 +483,10 @@ export default {
 </script>
 
 <style scoped>
+.rtl {
+  direction: rtl;
+}
+
 .highlight-container.highlight-container--bottom-labels {
   align-items: flex-start;
 }


### PR DESCRIPTION
Solves the issue -> [RTL language Support #769](https://github.com/doccano/doccano/issues/769)

In sequence labeling projects, check for first character of a the sentence, if it's right-to-left language (Arabic/Hebrew) it adds `rtl` class to CSS classes list of the `EntityItemBox` component.
