### PR TITLE
Autolabeling(Custom REST Request): Add a description on how to define the text field

### DIFF
--- a/frontend/components/configAutoLabeling/form/ConfigParameters.vue
+++ b/frontend/components/configAutoLabeling/form/ConfigParameters.vue
@@ -5,7 +5,7 @@
         <v-form>
           <h4 class="text-h6">Set parameters</h4>
           <p class="font-weight-regular body-1">
-            You can set parameters to fetch API response.
+            You can set parameters to fetch API response.The text will be send in the request through a field with a custom name. The field can be defined in Param, Headers or Body. To define it, set a key you want and set the value as "{{ text }}".
           </p>
           <template v-for="item in value">
             <v-text-field


### PR DESCRIPTION
I couldn't find any description on how to define the "text" field in the request made to the custom server. I ended up having to check it in the code. This short description may help others in the future.