### PR TITLE
Add keyboard shortcut back to accept button

### DIFF
--- a/frontend/components/tasks/toolbar/buttons/ButtonReview.vue
+++ b/frontend/components/tasks/toolbar/buttons/ButtonReview.vue
@@ -2,8 +2,10 @@
   <v-tooltip bottom>
     <template #activator="{ on }">
       <v-btn
+        v-shortkey.once="['enter']"
         icon
         v-on="on"
+        @shortkey="$emit('click:review')"
         @click="$emit('click:review')"
       >
         <v-icon v-if="isReviewd">


### PR DESCRIPTION
It seems like the "enter" key keyboard shortcut for the accept/review button functionality was lost at some point. See discussion in  #718 and issue #1398. This pull request restores the functionality