### PR TITLE
[Enhancement] Refactor Annotation API

### DIFF
--- a/backend/api/tests/api/test_annotation.py
+++ b/backend/api/tests/api/test_annotation.py
@@ -1,8 +1,8 @@
 from rest_framework import status
 from rest_framework.reverse import reverse
 
-from ...models import (DOCUMENT_CLASSIFICATION, SEQUENCE_LABELING, Category,
-                       Span)
+from ...models import (DOCUMENT_CLASSIFICATION, SEQ2SEQ, SEQUENCE_LABELING,
+                       Category, Span, TextLabel)
 from .utils import (CRUDMixin, make_annotation, make_doc, make_label,
                     make_user, prepare_project)
 
@@ -58,6 +58,12 @@ class TestSpanList(TestAnnotationList):
         make_annotation(cls.task, doc=doc, user=member, start_offset=0, end_offset=1)
 
 
+class TestTextList(TestAnnotationList):
+    model = TextLabel
+    task = SEQ2SEQ
+    view_name = 'text_list'
+
+
 class TestSharedAnnotationList(CRUDMixin):
     model = Category
     task = DOCUMENT_CLASSIFICATION
@@ -92,7 +98,7 @@ class TestSharedCategoryList(TestSharedAnnotationList):
     view_name = 'category_list'
 
 
-class TestSharedSpanList(TestSharedCategoryList):
+class TestSharedSpanList(TestSharedAnnotationList):
     model = Span
     task = SEQUENCE_LABELING
     view_name = 'span_list'
@@ -108,6 +114,12 @@ class TestSharedSpanList(TestSharedCategoryList):
             end_offset=cls.start_offset + 1
         )
         cls.start_offset += 1
+
+
+class TestSharedTextList(TestSharedAnnotationList):
+    model = TextLabel
+    task = SEQ2SEQ
+    view_name = 'text_list'
 
 
 class TestAnnotationCreation(CRUDMixin):
@@ -147,6 +159,14 @@ class TestSpanCreation(TestAnnotationCreation):
     def create_data(self):
         label = make_label(self.project.item)
         return {'label': label.id, 'start_offset': 0, 'end_offset': 1}
+
+
+class TestTextLabelCreation(TestAnnotationCreation):
+    task = SEQ2SEQ
+    view_name = 'text_list'
+
+    def create_data(self):
+        return {'text': 'example'}
 
 
 class TestAnnotationDetail(CRUDMixin):
@@ -218,6 +238,18 @@ class TestSpanDetail(TestAnnotationDetail):
     view_name = 'span_detail'
 
 
+class TestTextDetail(TestAnnotationDetail):
+    task = SEQ2SEQ
+    view_name = 'text_detail'
+
+    def setUp(self):
+        super().setUp()
+        self.data = {'text': 'changed'}
+
+    def create_annotation_data(self, doc):
+        return make_annotation(task=self.task, doc=doc, user=self.project.users[0])
+
+
 class TestSharedAnnotationDetail(CRUDMixin):
     task = DOCUMENT_CLASSIFICATION
     view_name = 'annotation_detail'
@@ -255,3 +287,12 @@ class TestSharedSpanDetail(TestSharedAnnotationDetail):
 
     def make_annotation(self, doc, member):
         return make_annotation(self.task, doc=doc, user=member, start_offset=0, end_offset=1)
+
+
+class TestSharedTextDetail(TestSharedAnnotationDetail):
+    task = SEQ2SEQ
+    view_name = 'text_detail'
+
+    def setUp(self):
+        super().setUp()
+        self.data = {'text': 'changed'}

--- a/backend/api/urls.py
+++ b/backend/api/urls.py
@@ -4,6 +4,7 @@ from .views import (annotation, annotation_relations, auto_labeling, comment,
                     example, example_state, export_dataset, health,
                     import_dataset, import_export, label, project,
                     relation_types, role, statistics, tag, task, user)
+from .views.tasks import category
 
 urlpatterns_project = [
     path(
@@ -111,6 +112,16 @@ urlpatterns_project = [
         route='docs/<int:doc_id>/annotations/<int:annotation_id>',
         view=annotation.AnnotationDetail.as_view(),
         name='annotation_detail'
+    ),
+    path(
+        route='examples/<int:example_id>/categories',
+        view=category.CategoryListAPI.as_view(),
+        name='category_list'
+    ),
+    path(
+        route='examples/<int:example_id>/categories/<int:annotation_id>',
+        view=category.CategoryDetailAPI.as_view(),
+        name='category_detail'
     ),
     path(
         route='tags',

--- a/backend/api/urls.py
+++ b/backend/api/urls.py
@@ -4,7 +4,7 @@ from .views import (annotation, annotation_relations, auto_labeling, comment,
                     example, example_state, export_dataset, health,
                     import_dataset, import_export, label, project,
                     relation_types, role, statistics, tag, task, user)
-from .views.tasks import category, span
+from .views.tasks import category, span, text
 
 urlpatterns_project = [
     path(
@@ -132,6 +132,16 @@ urlpatterns_project = [
         route='examples/<int:example_id>/spans/<int:annotation_id>',
         view=span.SpanDetailAPI.as_view(),
         name='span_detail'
+    ),
+    path(
+        route='examples/<int:example_id>/texts',
+        view=text.TextLabelListAPI.as_view(),
+        name='text_list'
+    ),
+    path(
+        route='examples/<int:example_id>/texts/<int:annotation_id>',
+        view=text.TextLabelDetailAPI.as_view(),
+        name='text_detail'
     ),
     path(
         route='tags',

--- a/backend/api/urls.py
+++ b/backend/api/urls.py
@@ -4,7 +4,7 @@ from .views import (annotation, annotation_relations, auto_labeling, comment,
                     example, example_state, export_dataset, health,
                     import_dataset, import_export, label, project,
                     relation_types, role, statistics, tag, task, user)
-from .views.tasks import category
+from .views.tasks import category, span
 
 urlpatterns_project = [
     path(
@@ -122,6 +122,16 @@ urlpatterns_project = [
         route='examples/<int:example_id>/categories/<int:annotation_id>',
         view=category.CategoryDetailAPI.as_view(),
         name='category_detail'
+    ),
+    path(
+        route='examples/<int:example_id>/spans',
+        view=span.SpanListAPI.as_view(),
+        name='span_list'
+    ),
+    path(
+        route='examples/<int:example_id>/spans/<int:annotation_id>',
+        view=span.SpanDetailAPI.as_view(),
+        name='span_detail'
     ),
     path(
         route='tags',

--- a/backend/api/views/tasks/base.py
+++ b/backend/api/views/tasks/base.py
@@ -1,0 +1,57 @@
+from django.core.exceptions import ValidationError
+from django.shortcuts import get_object_or_404
+from rest_framework import generics, status
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.response import Response
+
+from ...models import Project
+from ...permissions import IsInProjectOrAdmin, IsOwnAnnotation
+
+
+class BaseListAPI(generics.ListCreateAPIView):
+    annotation_class = None
+    pagination_class = None
+    permission_classes = [IsAuthenticated & IsInProjectOrAdmin]
+    swagger_schema = None
+
+    @property
+    def project(self):
+        return get_object_or_404(Project, pk=self.kwargs['project_id'])
+
+    def get_queryset(self):
+        queryset = self.annotation_class.objects.filter(example=self.kwargs['example_id'])
+        if not self.project.collaborative_annotation:
+            queryset = queryset.filter(user=self.request.user)
+        return queryset
+
+    def create(self, request, *args, **kwargs):
+        request.data['example'] = self.kwargs['example_id']
+        try:
+            response = super().create(request, args, kwargs)
+        except ValidationError as err:
+            response = Response({'detail': err.messages}, status=status.HTTP_400_BAD_REQUEST)
+        return response
+
+    def perform_create(self, serializer):
+        serializer.save(example_id=self.kwargs['example_id'], user=self.request.user)
+
+    def delete(self, request, *args, **kwargs):
+        queryset = self.get_queryset()
+        queryset.all().delete()
+        return Response(status=status.HTTP_204_NO_CONTENT)
+
+
+class BaseDetailAPI(generics.RetrieveUpdateDestroyAPIView):
+    lookup_url_kwarg = 'annotation_id'
+    swagger_schema = None
+
+    @property
+    def project(self):
+        return get_object_or_404(Project, pk=self.kwargs['project_id'])
+
+    def get_permissions(self):
+        if self.project.collaborative_annotation:
+            self.permission_classes = [IsAuthenticated & IsInProjectOrAdmin]
+        else:
+            self.permission_classes = [IsAuthenticated & IsInProjectOrAdmin & IsOwnAnnotation]
+        return super().get_permissions()

--- a/backend/api/views/tasks/category.py
+++ b/backend/api/views/tasks/category.py
@@ -1,0 +1,18 @@
+from ...models import Category
+from ...serializers import CategorySerializer
+from .base import BaseDetailAPI, BaseListAPI
+
+
+class CategoryListAPI(BaseListAPI):
+    annotation_class = Category
+    serializer_class = CategorySerializer
+
+    def create(self, request, *args, **kwargs):
+        if self.project.single_class_classification:
+            self.get_queryset().delete()
+        return super().create(request, args, kwargs)
+
+
+class CategoryDetailAPI(BaseDetailAPI):
+    queryset = Category.objects.all()
+    serializer_class = CategorySerializer

--- a/backend/api/views/tasks/span.py
+++ b/backend/api/views/tasks/span.py
@@ -1,0 +1,13 @@
+from ...models import Span
+from ...serializers import SpanSerializer
+from .base import BaseDetailAPI, BaseListAPI
+
+
+class SpanListAPI(BaseListAPI):
+    annotation_class = Span
+    serializer_class = SpanSerializer
+
+
+class SpanDetailAPI(BaseDetailAPI):
+    queryset = Span.objects.all()
+    serializer_class = SpanSerializer

--- a/backend/api/views/tasks/text.py
+++ b/backend/api/views/tasks/text.py
@@ -1,0 +1,13 @@
+from ...models import TextLabel
+from ...serializers import TextLabelSerializer
+from .base import BaseDetailAPI, BaseListAPI
+
+
+class TextLabelListAPI(BaseListAPI):
+    annotation_class = TextLabel
+    serializer_class = TextLabelSerializer
+
+
+class TextLabelDetailAPI(BaseDetailAPI):
+    queryset = TextLabel.objects.all()
+    serializer_class = TextLabelSerializer

--- a/frontend/repositories/tasks/seq2seq/apiSeq2seq.ts
+++ b/frontend/repositories/tasks/seq2seq/apiSeq2seq.ts
@@ -14,6 +14,6 @@ export class APISeq2seqRepository extends AnnotationRepository<Seq2seqLabel> {
   }
 
   protected baseUrl(projectId: string, docId: number): string {
-    return `/projects/${projectId}/docs/${docId}/annotations`
+    return `/projects/${projectId}/examples/${docId}/texts`
   }
 }

--- a/frontend/repositories/tasks/sequenceLabeling/apiSequenceLabeling.ts
+++ b/frontend/repositories/tasks/sequenceLabeling/apiSequenceLabeling.ts
@@ -14,6 +14,6 @@ export class APISequenceLabelingRepository extends AnnotationRepository<Sequence
   }
 
   protected baseUrl(projectId: string, docId: number): string {
-    return `/projects/${projectId}/docs/${docId}/annotations`
+    return `/projects/${projectId}/examples/${docId}/spans`
   }
 }

--- a/frontend/repositories/tasks/textClassification/apiTextClassification.ts
+++ b/frontend/repositories/tasks/textClassification/apiTextClassification.ts
@@ -8,6 +8,6 @@ export class APITextClassificationRepository extends AnnotationRepository<TextCl
   }
 
   protected baseUrl(projectId: string, docId: number): string {
-    return `/projects/${projectId}/docs/${docId}/annotations`
+    return `/projects/${projectId}/examples/${docId}/categories`
   }
 }


### PR DESCRIPTION
Currently, there is an endpoint to annotate data(`/annotations`). This is not useful for some tasks like #617 and relation extraction(this requires NER and relation labeling at the same time).
The new endpoints are divided into three separate ones:

- `/categories`
- `/spans`
- `/texts`
