### PR TITLE
Add examplestates to the response of ExampleList API

### DIFF
--- a/backend/api/serializers.py
+++ b/backend/api/serializers.py
@@ -83,6 +83,7 @@ class ExampleSerializer(serializers.ModelSerializer):
     annotations = serializers.SerializerMethodField()
     annotation_approver = serializers.SerializerMethodField()
     is_confirmed = serializers.SerializerMethodField()
+    states = serializers.SerializerMethodField()
 
     def get_annotations(self, instance):
         request = self.context.get('request')
@@ -94,6 +95,13 @@ class ExampleSerializer(serializers.ModelSerializer):
             annotations = annotations.filter(user=request.user)
         serializer = serializer(annotations, many=True)
         return serializer.data
+
+    def get_states(self, instance):
+        return [{
+            'confirmed_by_id': state.confirmed_by.id,
+            'confirmed_by_username': state.confirmed_by.username,
+            'confirmed_at': state.confirmed_at,
+        } for state in instance.states.all()]
 
     @classmethod
     def get_annotation_approver(cls, instance):
@@ -120,7 +128,8 @@ class ExampleSerializer(serializers.ModelSerializer):
             'annotation_approver',
             'comment_count',
             'text',
-            'is_confirmed'
+            'is_confirmed',
+            'states',
         ]
         read_only_fields = ['filename', 'is_confirmed']
 

--- a/backend/api/tests/api/test_document.py
+++ b/backend/api/tests/api/test_document.py
@@ -56,6 +56,25 @@ class TestExampleListAPI(CRUDMixin):
         response = self.assert_fetch(self.project.users[1], status.HTTP_200_OK)
         self.assertFalse(response.data['results'][0]['is_confirmed'])
 
+    def test_states(self):
+        example_state1 = make_example_state(self.example, self.project.users[0])
+        example_state2 = make_example_state(self.example, self.project.users[1])
+        response = self.assert_fetch(self.project.users[0], status.HTTP_200_OK)
+        states = response.data['results'][0]['states']
+        expected = [
+            {
+                'confirmed_by_id': example_state1.confirmed_by.id,
+                'confirmed_by_username': example_state1.confirmed_by.username,
+                'confirmed_at': example_state1.confirmed_at,
+            },
+            {
+                'confirmed_by_id': example_state2.confirmed_by.id,
+                'confirmed_by_username': example_state2.confirmed_by.username,
+                'confirmed_at': example_state2.confirmed_at,
+            },
+        ]
+        self.assertEqual(states, expected)
+
 
 class TestExampleListCollaborative(CRUDMixin):
     def setUp(self):


### PR DESCRIPTION
## What this PR do
- Add examplestate data associated with the esample to the response of ExampleList API.
- Add a test case.

## Why
- To analyze who and when annotated.

## API Response Diff
endpoint: `v1/projects/{project_id}/docs`

### Before
```py
{'count': 1,
  'next': None,
  'previous': None,
  'results': [{'annotation_approver': None,
    'annotations': [{'created_at': '2021-12-20T01:03:30.739215Z',
      'end_offset': 5,
      'example': 1,
      'id': 1,
      'label': 1,
      'prob': 0.0,
      'start_offset': 3,
      'updated_at': '2021-12-20T01:03:30.739242Z',
      'user': 1}]
    'comment_count': 0,
    'filename': 'http://localhost/media/backend/media/xxx/xxx/xxx.jsonl',
    'id': 1,
    'is_confirmed': False,
    'meta': {},
    'text': 'sample text'}
  ]
}
```

### After
```py
{'count': 1,
  'next': None,
  'previous': None,
  'results': [{'annotation_approver': None,
    'annotations': [{'created_at': '2021-12-20T01:03:30.739215Z',
      'end_offset': 5,
      'example': 1,
      'id': 1,
      'label': 1,
      'prob': 0.0,
      'start_offset': 3,
      'updated_at': '2021-12-20T01:03:30.739242Z',
      'user': 1}]
    'comment_count': 0,
    'filename': 'http://localhost/media/backend/media/xxx/xxx/xxx.jsonl',
    'id': 1,
    'is_confirmed': False,
    'meta': {},
    # added
    'states': [{'confirmed_at': '2021-12-20T08:25:33.025213Z',
              'confirmed_by_id': 1,
              'confirmed_by_username': 'admin'},
             {'confirmed_at': '2021-12-21T09:54:18.362754Z',
              'confirmed_by_id': 2,
              'confirmed_by_username': 'annotator'}],
    'text': 'sample text'}
  ]
}
```