### PR TITLE
Python 3.7 compatability

### DIFF
--- a/backend/api/models.py
+++ b/backend/api/models.py
@@ -1,8 +1,12 @@
 import random
 import string
 import uuid
-from typing import Literal
+try:
+    from typing import Literal
+except ImportError:
+    from typing_extensions import Literal
 
+    
 from auto_labeling_pipeline.models import RequestModelFactory
 from django.contrib.auth.models import User
 from django.core.exceptions import ValidationError


### PR DESCRIPTION
This PR fixes `doccano init` to fail on Python 3.7 with

```
Traceback (most recent call last):
  File "/usr/lib/python3.7/code.py", line 90, in runcode
    exec(code, self.locals)
  File "<input>", line 1, in <module>
ImportError: cannot import name 'Literal' from 'typing' (/usr/lib/python3.7/typing.py)
```
see https://stackoverflow.com/questions/61206437/importerror-cannot-import-name-literal-from-typing?noredirect=1&lq=1


