### PR TITLE
Fix state of label selection on LabelingMenu for sequenceLabeling

### DIFF
--- a/frontend/components/tasks/sequenceLabeling/LabelingMenu.vue
+++ b/frontend/components/tasks/sequenceLabeling/LabelingMenu.vue
@@ -107,7 +107,7 @@ export default Vue.extend({
       // Todo: a bit hacky. I want to fix this problem.
       // https://github.com/vuetifyjs/vuetify/issues/10765
       this.$nextTick(() => {
-        this.value = undefined;
+        this.value = null
         if (this.$refs.autocomplete) {
           (this.$refs.autocomplete as any).selectedItems = []
         }
@@ -116,7 +116,7 @@ export default Vue.extend({
     },
 
     onLabelSelected(labelId: number) {
-      this.value= labelId;
+      this.value = labelId
       this.$emit('click:label', labelId)
       this.close()
     }

--- a/frontend/components/tasks/sequenceLabeling/LabelingMenu.vue
+++ b/frontend/components/tasks/sequenceLabeling/LabelingMenu.vue
@@ -16,7 +16,7 @@
       <v-list-item>
         <v-autocomplete
           ref="autocomplete"
-          :value="selectedLabel"
+          v-model="value"
           :items="labels"
           autofocus
           dense
@@ -92,6 +92,7 @@ export default Vue.extend({
       entity: null as any,
       fromEntity: null as any,
       toEntity: null as any,
+      value: this.selectedLabel
     };
   },
 
@@ -106,6 +107,7 @@ export default Vue.extend({
       // Todo: a bit hacky. I want to fix this problem.
       // https://github.com/vuetifyjs/vuetify/issues/10765
       this.$nextTick(() => {
+        this.value = undefined;
         if (this.$refs.autocomplete) {
           (this.$refs.autocomplete as any).selectedItems = []
         }
@@ -114,6 +116,7 @@ export default Vue.extend({
     },
 
     onLabelSelected(labelId: number) {
+      this.value= labelId;
       this.$emit('click:label', labelId)
       this.close()
     }


### PR DESCRIPTION
Currently labeling two entities with the same label by choosing it from the
autocomplete, didn't work. Labeling the first entity worked, but when you
tried to label a new entity with the same label chosen from the
autocomplete, nothing happened.