### PR TITLE
Fix migration when adding uuids

### DIFF
--- a/backend/api/migrations/0017_example_uuid.py
+++ b/backend/api/migrations/0017_example_uuid.py
@@ -5,6 +5,13 @@ import uuid
 from django.db import migrations, models
 
 
+def create_uuid(apps, schema_editor):
+    Example = apps.get_model('api', 'example')
+    for example in Example.objects.all():
+        example.uuid = uuid.uuid4()
+        example.save()
+
+
 class Migration(migrations.Migration):
 
     dependencies = [
@@ -15,6 +22,12 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name="example",
             name="uuid",
-            field=models.UUIDField(db_index=True, default=uuid.uuid4, editable=False, unique=True),
+            field=models.UUIDField(editable=False, blank=True, null=True),
         ),
+        migrations.RunPython(create_uuid),
+        migrations.AlterField(
+            model_name='example',
+            name='uuid',
+            field=models.UUIDField(db_index=True, unique=True)
+        )
     ]

--- a/backend/api/migrations/0017_example_uuid.py
+++ b/backend/api/migrations/0017_example_uuid.py
@@ -6,7 +6,7 @@ from django.db import migrations, models
 
 
 def create_uuid(apps, schema_editor):
-    Example = apps.get_model('api', 'example')
+    Example = apps.get_model("api", "example")
     for example in Example.objects.all():
         example.uuid = uuid.uuid4()
         example.save()
@@ -25,9 +25,5 @@ class Migration(migrations.Migration):
             field=models.UUIDField(editable=False, blank=True, null=True),
         ),
         migrations.RunPython(create_uuid),
-        migrations.AlterField(
-            model_name='example',
-            name='uuid',
-            field=models.UUIDField(db_index=True, unique=True)
-        )
+        migrations.AlterField(model_name="example", name="uuid", field=models.UUIDField(db_index=True, unique=True)),
     ]

--- a/backend/api/migrations/0017_example_uuid.py
+++ b/backend/api/migrations/0017_example_uuid.py
@@ -9,7 +9,7 @@ def create_uuid(apps, schema_editor):
     Example = apps.get_model("api", "example")
     for example in Example.objects.all():
         example.uuid = uuid.uuid4()
-        example.save()
+        example.save(update_fields=["uuid"])
 
 
 class Migration(migrations.Migration):
@@ -24,6 +24,8 @@ class Migration(migrations.Migration):
             name="uuid",
             field=models.UUIDField(editable=False, blank=True, null=True),
         ),
-        migrations.RunPython(create_uuid),
-        migrations.AlterField(model_name="example", name="uuid", field=models.UUIDField(db_index=True, unique=True)),
+        migrations.RunPython(create_uuid, reverse_code=migrations.RunPython.noop),
+        migrations.AlterField(
+            model_name="example", name="uuid", field=models.UUIDField(default=uuid.uuid4, db_index=True, unique=True)
+        ),
     ]


### PR DESCRIPTION
This is a fix for #1595.

What happened was that if there was data in the DB, a single uuid4 value would be created, so the migration would fail because of the unique constraint. 

The change is to first create the field, without a unique constraint and with null values, run a Python function to create uuid4s for each Example, and then change the field to have the unique constraints. 