### PR TITLE
Replace git:// with https://

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -13,6 +13,8 @@ jobs:
     - name: Preparation
       run: |
         mkdir backend/client
+    - name: Fix up git URLs
+      run: echo -e '[url "https://github.com/"]\n  insteadOf = "git@github.com:"' >> ~/.gitconfig
     - name: Use Node.js
       uses: actions/setup-node@v1
       with:

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -8,6 +8,7 @@ ENV PUBLIC_PATH="/static/_nuxt/"
 
 # hadolint ignore=DL3018
 RUN apk add -U --no-cache git python3 make g++ \
+ && git config --global url."https://github.com/".insteadOf git://github.com/ \
  && yarn install \
  && yarn build \
  && apk del --no-cache git make g++

--- a/docker/Dockerfile.nginx
+++ b/docker/Dockerfile.nginx
@@ -6,6 +6,7 @@ WORKDIR /app
 
 RUN apt-get update \
  && apt-get install -y git python3 make g++ \
+ && git config --global url."https://github.com/".insteadOf git://github.com/ \
  && yarn install \
  && yarn build \
  && apt-get clean


### PR DESCRIPTION
Fix the following error:

```bash
The unauthenticated git protocol on port 9418 is no longer supported.
```

Related to:

- https://github.blog/2021-09-01-improving-git-protocol-security-github/