### PR TITLE
fix de, fr and zh messages

### DIFF
--- a/frontend/i18n/de/rules.js
+++ b/frontend/i18n/de/rules.js
@@ -29,7 +29,7 @@ export default {
   },
   uploadFileRules: {
     fileRequired: 'Datei(en) werden benötigt',
-    fileLessThan1MB: 'Dateigröße muss kleiner als 1 MB sein!'
+    fileLessThan1MB: 'Dateigröße muss kleiner als 100 MB sein!'
   },
   passwordRules: {
     passwordRequired: 'Passwort wird benötigt',

--- a/frontend/i18n/fr/rules.js
+++ b/frontend/i18n/fr/rules.js
@@ -29,7 +29,7 @@ export default {
   },
   uploadFileRules: {
     fileRequired: 'Le fichier est obligatoire',
-    fileLessThan1MB: 'La taille du fichier doit être inférieure à 1MB'
+    fileLessThan1MB: 'La taille du fichier doit être inférieure à 100 MB'
   },
   passwordRules: {
     passwordRequired: 'Le mot de passe est obligatoire',

--- a/frontend/i18n/zh/rules.js
+++ b/frontend/i18n/zh/rules.js
@@ -33,7 +33,7 @@ export default {
   },
   uploadFileRules: {
     fileRequired: '请输入文件',
-    fileLessThan1MB: '文件大小必须小于 1 MB!'
+    fileLessThan1MB: '文件大小必须小于 100 MB!'
   },
   passwordRules: {
     passwordRequired: '请输入密码',


### PR DESCRIPTION
regarding #1175, max upload size was increased  from 1MB to 100 MB.

But, only English message was fixed.  

```
de/rules.js:    fileLessThan1MB: 'Dateigröße muss kleiner als 1 MB sein!'
en/rules.js:    fileLessThan1MB: 'File size should be less than 100 MB!'
fr/rules.js:    fileLessThan1MB: 'La taille du fichier doit être inférieure à 1MB'
zh/rules.js:    fileLessThan1MB: '文件大小必须小于 1 MB!'
```