### PR TITLE
Update RabbitMQ version

### DIFF
--- a/docker/docker-compose.prod.yml
+++ b/docker/docker-compose.prod.yml
@@ -46,7 +46,7 @@ services:
       - network-backend
 
   rabbitmq:
-    image: rabbitmq:3.8-alpine
+    image: rabbitmq:3.10.7-alpine
     environment:
       RABBITMQ_DEFAULT_USER: "${RABBITMQ_DEFAULT_USER}"
       RABBITMQ_DEFAULT_PASS: "${RABBITMQ_DEFAULT_PASS}"


### PR DESCRIPTION
The EOL date of RabbitMQ 3.8 is 2022/07/31. So update to 3.10.

- [Release Series | RabbitMQ](https://www.rabbitmq.com/versions.html)