### PR TITLE
Enable to set worker processes by environment variable

### DIFF
--- a/docker/Dockerfile.nginx
+++ b/docker/Dockerfile.nginx
@@ -17,12 +17,13 @@ RUN addgroup -g 61000 doccano \
   && adduser -G doccano -S doccano -u 61000
 
 COPY --chown=doccano:doccano --from=frontend-builder /app/dist /var/www/html
-COPY docker/nginx/nginx.conf /etc/nginx/nginx.conf
+COPY docker/nginx/nginx.conf.template /etc/nginx/nginx.conf.template
 COPY docker/nginx/default.conf /etc/nginx/conf.d/default.conf
 
 RUN chown -R doccano:doccano /var/cache/nginx \
   && chmod -R g+w /var/cache/nginx \
-  && chown -R doccano:doccano /media
+  && chown -R doccano:doccano /media \
+  && chown -R doccano:doccano /etc/nginx
 
 EXPOSE 8080
 

--- a/docker/docker-compose.prod.yml
+++ b/docker/docker-compose.prod.yml
@@ -60,9 +60,17 @@ services:
       context: ..
       dockerfile: docker/Dockerfile.nginx
     image: doccano_nginx:prod
+    command: >
+      /bin/sh -c
+      "envsubst '
+      $${WORKER_PROCESSES}
+      '< /etc/nginx/nginx.conf.template
+      > /etc/nginx/nginx.conf
+      && nginx -g 'daemon off;'"
     environment:
       API_URL: "http://backend:8000"
       GOOGLE_TRACKING_ID: ""
+      WORKER_PROCESSES: "auto"
     volumes:
       - static_volume:/static
       - media:/media

--- a/docker/nginx/nginx.conf.template
+++ b/docker/nginx/nginx.conf.template
@@ -1,4 +1,4 @@
-worker_processes  auto;
+worker_processes  ${WORKER_PROCESSES};
 
 error_log  /var/log/nginx/error.log warn;
 


### PR DESCRIPTION
- Enable to change the worker processes for Nginx
- Specify a number or `auto` to `WORKER_PROCESSES` 
- The default value is `auto`