### PR TITLE
Fix nuxt build problem

### DIFF
--- a/frontend/pages/projects/index.vue
+++ b/frontend/pages/projects/index.vue
@@ -31,7 +31,11 @@ import _ from 'lodash'
 import Vue from 'vue'
 import { mapGetters } from 'vuex'
 import ProjectList from '@/components/project/ProjectList.vue'
-import { ProjectDTO, ProjectListDTO } from '~/services/application/project/projectData'
+import {
+  ProjectDTO,
+  ProjectListDTO,
+  SearchQueryData
+} from '~/services/application/project/projectData'
 import FormDelete from '~/components/project/FormDelete.vue'
 
 export default Vue.extend({
@@ -54,7 +58,9 @@ export default Vue.extend({
 
   async fetch() {
     this.isLoading = true
-    this.projects = await this.$services.project.list(this.$route.query)
+    this.projects = await this.$services.project.list(
+      this.$route.query as unknown as SearchQueryData
+    )
     this.isLoading = false
   },
 


### PR DESCRIPTION
Fix the following problem:

```bash
#16 244.0 ERROR in pages/projects/index.vue:57:55
#16 244.0 TS2345: Argument of type 'Dictionary<string | (string | null)[]>' is not assignable to parameter of type 'SearchQueryData'.
#16 244.0   Type 'Dictionary<string | (string | null)[]>' is missing the following properties from type 'SearchQueryData': limit, offset
#16 244.0     55 |   async fetch() {
#16 244.0     56 |     this.isLoading = true
#16 244.0   > 57 |     this.projects = await this.$services.project.list(this.$route.query)
#16 244.0        |                                                       ^^^^^^^^^^^^^^^^^
#16 244.0     58 |     this.isLoading = false
#16 244.0     59 |   },
#16 244.0     60 |
#16 244.0 
#16 244.0  FATAL  Nuxt build error
```