### PR TITLE
[Enhancement] Use pre-build images to avoid building images in docker-compose

### DIFF
--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -45,3 +45,21 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.docker_meta.outputs.tags }}
           labels: ${{ steps.docker_meta.outputs.labels }}
+
+      - name: Build a backend image and push
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          file: ./docker/Dockerfile.prod
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: doccano/doccano:backend
+          labels: ${{ steps.docker_meta.outputs.labels }}
+      
+      - name: Build a frontend image and push
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          file: ./docker/Dockerfile.nginx
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: doccano/doccano:frontend
+          labels: ${{ steps.docker_meta.outputs.labels }}

--- a/docker/docker-compose.prod.yml
+++ b/docker/docker-compose.prod.yml
@@ -2,10 +2,7 @@ version: "3.7"
 services:
 
   backend:
-    build:
-      context: ..
-      dockerfile: docker/Dockerfile.prod
-    image: doccano_backend:prod
+    image: doccano/doccano:backend
     volumes:
       - static_volume:/backend/staticfiles
       - media:/backend/media
@@ -26,10 +23,7 @@ services:
       - network-frontend
 
   celery:
-    build:
-      context: ..
-      dockerfile: docker/Dockerfile.prod
-    image: doccano_celery:prod
+    image: doccano/doccano:backend
     volumes:
       - media:/backend/media
       - tmp_file:/backend/filepond-temp-uploads
@@ -46,10 +40,7 @@ services:
       - network-backend
 
   flower:
-    build:
-      context: ..
-      dockerfile: docker/Dockerfile.prod
-    image: doccano_flower:prod
+    image: doccano/doccano:backend
     entrypoint: ["/opt/bin/prod-flower.sh"]
     environment:
       PYTHONUNBUFFERED: "1"
@@ -76,10 +67,7 @@ services:
       - network-backend
 
   nginx:
-    build:
-      context: ..
-      dockerfile: docker/Dockerfile.nginx
-    image: doccano_nginx:prod
+    image: doccano/doccano:frontend
     command: >
       /bin/sh -c
       "envsubst '


### PR DESCRIPTION
To resolve the following issues, this PR updates a workflow for building and pushing Docker images and uses them in docker-compose.prod.yml to avoid building images.

resolve #971
resolve #983