### PR TITLE
Handle JSONDecodeError on testing auto labeling API

### DIFF
--- a/backend/auto_labeling/exceptions.py
+++ b/backend/auto_labeling/exceptions.py
@@ -24,3 +24,7 @@ class SampleDataException(ValidationError):
 
 class TemplateMappingError(ValidationError):
     default_detail = "The response cannot be mapped. You might need to change the template."
+
+
+class ResponseJSONDecodeError(ValidationError):
+    default_detail = "The response cannot be decoded." "Please try to return the response in dictionary or list format."

--- a/backend/auto_labeling/views.py
+++ b/backend/auto_labeling/views.py
@@ -17,6 +17,7 @@ from rest_framework.views import APIView
 
 from .exceptions import (
     AWSTokenError,
+    ResponseJSONDecodeError,
     SampleDataException,
     TemplateMappingError,
     URLConnectionError,
@@ -94,6 +95,8 @@ class RestAPIRequestTesting(APIView):
             raise URLConnectionError
         except botocore.exceptions.ClientError:
             raise AWSTokenError()
+        except json.decoder.JSONDecodeError:
+            raise ResponseJSONDecodeError()
         except Exception as e:
             raise e
 


### PR DESCRIPTION
Showed a bit better message:

Before:
![image](https://user-images.githubusercontent.com/6737785/190100764-cec52d49-1c11-479e-a086-f42501e464da.png)

After:
![image](https://user-images.githubusercontent.com/6737785/190100809-251cae65-9f01-425b-863e-7ebc31f8102e.png)
