### PR TITLE
Update cli to avoid ValueError: path must be a filename, not a directory.

### DIFF
--- a/backend/cli.py
+++ b/backend/cli.py
@@ -155,7 +155,7 @@ def main():
     # Create a parser for task queue.
     parser_queue = subparsers.add_parser("task", help="see `task -h`")
     parser_queue.add_argument("--concurrency", type=int, default=2, help="concurrency")
-    parser_queue.add_argument("--env_file", type=str, default="", help="read in a file of environment variables")
+    parser_queue.add_argument("--env_file", type=str, help="read in a file of environment variables")
     parser_queue.set_defaults(handler=command_run_task_queue)
 
     parser_flower = subparsers.add_parser("flower", help="see `flower -h`")


### PR DESCRIPTION
fix #2086 
fix #2072 
fix #2073 
fix #2080 
