### PR TITLE
Fix project store to use Project model

### DIFF
--- a/frontend/store/projects.js
+++ b/frontend/store/projects.js
@@ -14,13 +14,7 @@ export const getters = {
 
 export const mutations = {
   setCurrent(state, payload) {
-    state.current = {
-      ...payload,
-      canDefineCategory: payload.canDefineCategory,
-      canDefineLabel: payload.canDefineLabel,
-      canDefineRelation: payload.canDefineRelation,
-      canDefineSpan: payload.canDefineSpan
-    }
+    state.current = payload
   }
 }
 


### PR DESCRIPTION
Currently, `setCurrent` method converts `Project` into an object. As a result, some method like `isImageProject` cannot be used. This PR fixes the problem.