### PR TITLE
Fix appearance of lists in doccano docs

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -1,23 +1,20 @@
 # FAQ
 
 ## How to create a user
-To create a new doccano user: 
+
+To create a new doccano user:
+
 1. Run the doccano webserver. 
-2. Log in to the admin site (in the case of pip installation) via <http://localhost:{port}/admin/>. The example below uses the port `8000` and username `admin`. If you set your own port or username and password on running the server, use those values to log in.
+2. Log in to the admin site (in the case of pip installation) via <http://localhost:{port}/admin/>. 
 
-   ![](images/faq/user_creation/login.png)
-
+      The example below uses the port `8000` and username `admin`. If you set your own port or username and password on running the server, use those values to log in.
+      ![](images/faq/user_creation/login.png)
 3. After logging in to the admin site, click **Users**:
-
-   ![](images/faq/user_creation/select_users.png)
-
+      ![](images/faq/user_creation/select_users.png)
 4. Click the **ADD USER** button in the upper right corner:
-
-   ![](images/faq/user_creation/select_add_user.png)
-
+      ![](images/faq/user_creation/select_add_user.png)
 5. After entering the username and password for the new user, click **SAVE**:
-
-   ![](images/faq/user_creation/create_user.png)
+      ![](images/faq/user_creation/create_user.png)
 
 Congratulations. Now you can log in to doccano as a new user. After logging out of the admin site, try logging in to doccano as a new user.
 
@@ -30,13 +27,10 @@ To add a user to your project:
 1. Log in to doccano. 
 2. Click on your project. 
 3. From the left side menu, click **Members**. If you are not the administrator of the project, **Members** will not appear.
-
-   ![](images/faq/add_annotator/select_members.png)
-
+      ![](images/faq/add_annotator/select_members.png)
 4. Click **Add** and fill in the Add Member form with the user name and role you want to add to the project. 
 5. Click **Save**.
-
-![](images/faq/add_annotator/select_user.png)
+      ![](images/faq/add_annotator/select_user.png)
 
 Now the new user can access the project.
 
@@ -47,25 +41,16 @@ To change a user's password:
 1. Run the doccano webserver.
 2. Log in to the admin site (in the case of pip installation) via <http://localhost:{port}/admin/>. 
 
-   **Note**: You need to have a staff permission to log in to the admin site. If you don't have the right permissions, ask the administrator to change your password.
-
-   ![](images/faq/user_creation/login.png)
-
+      **Note**: You need to have a staff permission to log in to the admin site. If you don't have the right permissions, ask the administrator to change your password.
+      ![](images/faq/user_creation/login.png)
 3. Click **Users**.
-
-  ![](images/faq/user_creation/select_users.png)
-
+      ![](images/faq/user_creation/select_users.png)
 4. Click on the name of the user whose password you want to change:
-
-   ![](images/faq/how_to_change_password/user_list.png)
-
+      ![](images/faq/how_to_change_password/user_list.png)
 5. Click the link that says **this form** in the password section.
-
-   ![](images/faq/how_to_change_password/user_page.png)
-
+      ![](images/faq/how_to_change_password/user_page.png)
 6. Fill out the form and change the password. 
-
-   ![](images/faq/how_to_change_password/change_password.png)
+      ![](images/faq/how_to_change_password/change_password.png)
 
 ## I can't upload my data
 
@@ -89,29 +74,29 @@ In the case of Docker Compose, you can change the port number by editing `docker
 
 1. Change `80:8080` to `<your_port>:8080` in `nginx`/`ports` section as follows:
 
-   ```yaml
-   nginx:
-     image: doccano/doccano:frontend
-     ports:
-       - <your_port>:8080
-   ```
+      ```yaml
+      nginx:
+         image: doccano/doccano:frontend
+         ports:
+         - <your_port>:8080
+      ```
 
 2. Add the `CSRF_TRUSTED_ORIGINS` environment variable to the `backend`/`environment` section as follows:
 
-   ```yaml
+```yaml
    backend:
-       image: doccano/doccano:backend
-       environment:
+      image: doccano/doccano:backend
+      environment:
          ...
          DJANGO_SETTINGS_MODULE: "config.settings.production"
          CSRF_TRUSTED_ORIGINS: "http://127.0.0.1:<your_port>"
-   ```
+```
 
 ## I want to update to the latest doccano image
 
 1. Execute `git pull` to reflect the latest doccano.
-2. Delete the volume that `doccano_node_modules`, `doccano_static_volume`, `doccano_venv` and `doccano_www`.
-  **Do not delete `doccano_postgres_data` because it stores your projects data.**
+2. Delete the volume that `doccano_node_modules`, `doccano_static_volume`, `doccano_venv` and `doccano_www`. 
+   **Do not delete `doccano_postgres_data` because it stores your projects data.**
 3. Rebuild the doccano image.
 
 The following commands are the procedure for 2~3.

--- a/docs/index.md
+++ b/docs/index.md
@@ -25,26 +25,24 @@ To complete a labeling project with doccano:
 
 1. Install doccano with pip (Python 3.8+):
 
-   ```bash
-   pip install doccano
-   ```
+      ```bash
+      pip install doccano
+      ```
 
 2. Run doccano:
 
-   ```bash
-   doccano init
-   doccano createuser
-   doccano webserver
-
-   # In another terminal, run the command:
-   doccano task
-   ```
+         doccano init
+         doccano createuser
+         doccano webserver
+         # In another terminal, run the command:
+         doccano task
 
 3. Open the doccano UI at <http://localhost:8000/auth>.
-4. Sign in with the username and password created by `doccano createuser`. The default is **username:** admin, **password:** password.
+4. Sign in with the username and password created by `doccano createuser`.
+
+      The default is **username:** admin, **password:** password.
 
 5. Change the default admin password at <http://localhost:8000/admin/password_change/>.
-
 6. Return to the doccano UI at <http://localhost:8000/projects?>. 
 7. Create a project for labeling data. Click **Create**, select a project type, and fill out project details.
 8. Import a dataset. Go to the **Dataset** page and click **Actions** >  **Import Dataset** and import the dataset you want to use.
@@ -61,6 +59,6 @@ You can customize doccano to suit your needs. The architecture of doccano consis
 | [doccano frontend](https://github.com/doccano/doccano/tree/master/frontend) | Javascript web app using [Vue.js](https://vuejs.org/) and [Nuxt.js](https://nuxtjs.org/) | Perform data labeling in a user interface. |
 
 ## Contact
-If you get stuck, check the [FAQ](../docs/faq.md).
+If you get stuck, check the [FAQ](faq.md).
 
 For help and feedback, feel free to contact [the author](https://github.com/Hironsan).

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -17,13 +17,11 @@ Here is a JSON file named `books.json` containing lots of science fiction book d
 To start, let's create a new project for this task.
 
 1. Log in to doccano with the superuser account.
-
-   ![Sign in as a superuser.](./images/tutorial/signin.png)
-
-2. To create your project, go to the project list page and click **Create**
+      ![Sign in as a superuser.](./images/tutorial/signin.png)
+2. To create your project, go to the project list page and click **Create**.
 3. Fill out the project details. For this tutorial, name the project `sequence labeling for books`, write a description, and choose the sequence labeling task type.
 
-   ![Creating a project.](./images/tutorial/create_project.png)
+![Creating a project.](./images/tutorial/create_project.png)
 
 ## Import a dataset
 
@@ -32,10 +30,8 @@ After creating a project, the **Dataset** page appears.
 To import a dataset:
 
 1. Click **Actions** > **Import Dataset**. You should see the following screen:
-
-   ![Importing a dataset.](./images/tutorial/import_dataset.png)
-
-2. Choose **JSON** and click **Select a file.
+      ![Importing a dataset.](./images/tutorial/import_dataset.png)
+2. Choose **JSON** and click **Select a file**.
 3. Click **books.json** and it will load automatically.
 
 ## Define labels
@@ -45,20 +41,16 @@ Define the labels to use for your annotation project:
 1. Click **Labels** in the left side menu. You should see the label editor page. 
 2. On the label editor page, create labels by specifying label text, a shortcut key, background color, and text color. For this tutorial, let's create some entities related to science fiction, as shown below.
 
-  ![Defining labels.](./images/tutorial/define_labels.png)
+![Defining labels.](./images/tutorial/define_labels.png)
 
 ## Add members
 
 Members are users who can participate in labeling activities. To add members:
 
 1. Click **Members** in the left side menu. If you are not the project administrator, the button won't appear.
-
-   ![](images/faq/add_annotator/select_members.png)
-
+      ![](images/faq/add_annotator/select_members.png)
 2. Click **Add** to display the Add Member form. 
-
-   ![](images/faq/add_annotator/select_user.png)
-
+      ![](images/faq/add_annotator/select_user.png)
 3. Fill in the form with the user name and role you want to add to the project. If there is no user to select, you need to create the user first. See the [FAQ](./faq.md) for instructions.
 4. Click **Save**.
 


### PR DESCRIPTION
Fix formatting of doccano docs. 

- Fix formatting of text, code snippets in Index, FAQ, Tutorial in an ordered list (two tabs for images, two tabs for code snippets, no backticks for codeblocks included in an ordered list)
- Fix broken link to FAQ 

Note: When making changes for https://github.com/doccano/doccano/pull/2216, local markdown preview rendered markdown differently than published mkdocs. This time, used mkdocs locally to test/verify that changes render correctly. 