### PR TITLE
Remove dead 'Relations' link from side bar

### DIFF
--- a/frontend/components/layout/TheSideBar.vue
+++ b/frontend/components/layout/TheSideBar.vue
@@ -86,14 +86,6 @@ export default {
             this.project.canDefineLabel
         },
         {
-          icon: mdiLabel,
-          text: 'Relations',
-          link: 'links',
-          isVisible:
-            (this.isProjectAdmin || this.project.allowMemberToCreateLabelType) &&
-            this.project.canDefineRelation
-        },
-        {
           icon: mdiAccount,
           text: this.$t('members.members'),
           link: 'members',


### PR DESCRIPTION
This appears to be a relic from when the label type editor was organized differently (?). Now all the label types are unified under 'Labels', and the 'Relations' [link](https://github.com/doccano/doccano/blob/63870976cc62811807648075d04a2531a1a6734d/frontend/components/layout/TheSideBar.vue#L91C25-L91C25) is dead, as the route `projects/_id/links` does not exist anymore (deleted in 2465e5698c954815c717fcb9709fa7f1334b43b5).

Closes #2263. Closes #2272.