### PR TITLE
Added basic helm chart 

### DIFF
--- a/helm-chart/.helmignore
+++ b/helm-chart/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/helm-chart/Chart.lock
+++ b/helm-chart/Chart.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: postgresql
+  repository: https://charts.bitnami.com/bitnami
+  version: 12.9.0
+digest: sha256:1d5f67b5093e9745fda2cffcffc4658c13d39ba179584c25ead1892dcc48b77c
+generated: "2023-09-02T14:18:34.516896723+02:00"

--- a/helm-chart/Chart.yaml
+++ b/helm-chart/Chart.yaml
@@ -1,0 +1,30 @@
+apiVersion: v2
+name: doccano-app
+description: A Helm chart for Kubernetes
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.1
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: latest
+
+dependencies:
+  - name: postgresql
+    version: "12.9.*"
+    repository: https://charts.bitnami.com/bitnami
+    condition: postgresql.enabled

--- a/helm-chart/README.md
+++ b/helm-chart/README.md
@@ -1,0 +1,18 @@
+
+
+## Helm chart for running doccano docker image
+
+How to run:
+1. In the helm-chart directory run ``` helm dependency update ```
+2. ``` helm upgrade --install doccano-app . ```
+
+If you are using microk8s then start both of the above commands like so: ``` microk8s helm <commands> ``` or ```sudo microk8s <commands> ``` depending on your user privileges.
+
+### Docker image options
+
+The doccano version and repository can be changed in this line of the ``` values.yml ``` file:
+```
+repository: doccano/doccano
+tag: "1.8"
+```
+This is useful if you have built your own image and pushed it to a cloud/local container image registry.

--- a/helm-chart/templates/NOTES.txt
+++ b/helm-chart/templates/NOTES.txt
@@ -1,0 +1,22 @@
+1. Get the application URL by running these commands:
+{{- if .Values.ingress.enabled }}
+{{- range $host := .Values.ingress.hosts }}
+  {{- range .paths }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ .path }}
+  {{- end }}
+{{- end }}
+{{- else if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "doccano-app.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "doccano-app.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "doccano-app.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+  echo http://$SERVICE_IP:{{ .Values.service.port }}
+{{- else if contains "ClusterIP" .Values.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "doccano-app.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  export CONTAINER_PORT=$(kubectl get pod --namespace {{ .Release.Namespace }} $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
+  echo "Visit http://127.0.0.1:8080 to use your application"
+  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:$CONTAINER_PORT
+{{- end }}

--- a/helm-chart/templates/_helpers.tpl
+++ b/helm-chart/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "doccano-app.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "doccano-app.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "doccano-app.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "doccano-app.labels" -}}
+helm.sh/chart: {{ include "doccano-app.chart" . }}
+{{ include "doccano-app.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "doccano-app.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "doccano-app.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "doccano-app.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "doccano-app.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/helm-chart/templates/deployment.yaml
+++ b/helm-chart/templates/deployment.yaml
@@ -1,0 +1,115 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "doccano-app.fullname" . }}
+  labels:
+    {{- include "doccano-app.labels" . | nindent 4 }}
+spec:
+  {{- if not .Values.autoscaling.enabled }}
+  replicas: {{ .Values.replicaCount }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "doccano-app.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "doccano-app.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "doccano-app.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      volumes:
+        - name: doccano-data
+          persistentVolumeClaim:
+            claimName: {{ .Release.Name }}-persistant-volume
+      containers:
+        - name: {{ .Chart.Name }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.service.containerPort }}
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /
+              port: http
+            initialDelaySeconds: 120
+            periodSeconds: 30
+            timeoutSeconds: 5
+            successThreshold: 1
+            failureThreshold: 30
+          readinessProbe:
+            httpGet:
+              path: /
+              port: http
+            initialDelaySeconds: 120
+            periodSeconds: 30
+            timeoutSeconds: 5
+            successThreshold: 1
+            failureThreshold: 30
+          env:
+          - name: ADMIN_USERNAME
+            valueFrom:
+              secretKeyRef:
+                key:  admin_username
+                name: {{ .Release.Name }}-auth
+          - name: ADMIN_EMAIL
+            valueFrom:
+              secretKeyRef:
+                key:  admin_email
+                name: {{ .Release.Name }}-auth
+          - name: ADMIN_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                key:  admin_password
+                name: {{ .Release.Name }}-auth
+          - name: DATABASE_URL
+            valueFrom:
+              secretKeyRef:
+                key:  db_url
+                name: {{ .Release.Name }}-auth
+          - name: DEBUG
+            value: "{{ .Values.doccanoconfig.debug }}"
+          - name: STANDALONE
+            value: "{{ .Values.doccanoconfig.standalone }}"
+          - name: SECRET_KEY
+            value: {{ .Values.doccanoconfig.secret_key  }}
+          - name: PORT
+            value: "{{ .Values.doccanoconfig.port  }}"
+          - name: WORKERS
+            value: "{{ .Values.doccanoconfig.workers  }}"
+          - name: CELERY_WORKERS
+            value: "{{ .Values.doccanoconfig.celery_workers  }}"
+          - name: GOOGLE_TRACKING_ID
+            value: {{ .Values.doccanoconfig.google_tracking_id  }}
+          - name: DJANGO_SETTINGS_MODULE
+            value: {{ .Values.doccanoconfig.django_settings_module  }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          volumeMounts:
+            - mountPath: /doccano/backend/media
+              name: doccano-data
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/helm-chart/templates/doccano-app-postgres-secret.yml
+++ b/helm-chart/templates/doccano-app-postgres-secret.yml
@@ -1,0 +1,14 @@
+{{- if .Values.postgresql.secret.create }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: "{{ tpl (.Values.postgresql.secret.name) . }}"
+  namespace: {{ .Release.Namespace }}
+type: generic
+stringData:
+  database: {{ .Values.postgresql.auth.database }}
+  username: {{ .Values.postgresql.auth.username }}
+  password: {{ .Values.postgresql.secret.password }}
+  postgres-password: {{ .Values.postgresql.secret.postgres_password }}
+  replication-password: {{ .Values.postgresql.secret.replication_password }}
+{{- end }}

--- a/helm-chart/templates/hpa.yaml
+++ b/helm-chart/templates/hpa.yaml
@@ -1,0 +1,28 @@
+{{- if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2beta1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "doccano-app.fullname" . }}
+  labels:
+    {{- include "doccano-app.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "doccano-app.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+    {{- if .Values.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        targetAverageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        targetAverageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+{{- end }}

--- a/helm-chart/templates/ingress.yaml
+++ b/helm-chart/templates/ingress.yaml
@@ -1,0 +1,61 @@
+{{- if .Values.ingress.enabled -}}
+{{- $fullName := include "doccano-app.fullname" . -}}
+{{- $svcPort := .Values.service.port -}}
+{{- if and .Values.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
+  {{- if not (hasKey .Values.ingress.annotations "kubernetes.io/ingress.class") }}
+  {{- $_ := set .Values.ingress.annotations "kubernetes.io/ingress.class" .Values.ingress.className}}
+  {{- end }}
+{{- end }}
+{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1
+{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1beta1
+{{- else -}}
+apiVersion: extensions/v1beta1
+{{- end }}
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+    {{- include "doccano-app.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if and .Values.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            {{- if and .pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
+            pathType: {{ .pathType }}
+            {{- end }}
+            backend:
+              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $svcPort }}
+              {{- else }}
+              serviceName: {{ $fullName }}
+              servicePort: {{ $svcPort }}
+              {{- end }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/helm-chart/templates/secret.yaml
+++ b/helm-chart/templates/secret.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Release.Name }}-auth
+type: generic
+stringData:
+  admin_username: {{ .Values.doccanoconfig.admin_username }}
+  admin_email: {{ .Values.doccanoconfig.admin_email }}
+  admin_password: {{ .Values.doccanoconfig.admin_password }}
+  db_url: {{ .Values.doccanoconfig.db_url }}

--- a/helm-chart/templates/service.yaml
+++ b/helm-chart/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "doccano-app.fullname" . }}
+  labels:
+    {{- include "doccano-app.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "doccano-app.selectorLabels" . | nindent 4 }}

--- a/helm-chart/templates/serviceaccount.yaml
+++ b/helm-chart/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "doccano-app.serviceAccountName" . }}
+  labels:
+    {{- include "doccano-app.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/helm-chart/templates/storage.yaml
+++ b/helm-chart/templates/storage.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ .Release.Name }}-persistant-volume
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    "helm.sh/resource-policy": keep
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: microk8s-hostpath
+  resources:
+    requests:
+      storage: {{ .Values.doccanoconfig.persistant_storage_size }}

--- a/helm-chart/templates/tests/test-connection.yaml
+++ b/helm-chart/templates/tests/test-connection.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ include "doccano-app.fullname" . }}-test-connection"
+  labels:
+    {{- include "doccano-app.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test
+spec:
+  containers:
+    - name: wget
+      image: busybox
+      command: ['wget']
+      args: ['{{ include "doccano-app.fullname" . }}:{{ .Values.service.port }}']
+  restartPolicy: Never

--- a/helm-chart/values.yaml
+++ b/helm-chart/values.yaml
@@ -1,0 +1,120 @@
+# Default values for doccano-app.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+replicaCount: 1
+
+image:
+  repository: doccano/doccano
+  tag: "1.8"
+  pullPolicy: Always
+  # Overrides the image tag whose default is the chart appVersion.
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: false
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
+podAnnotations: {}
+
+podSecurityContext:
+  runAsUser: 1000
+  fsGroup: 1000
+  
+
+securityContext: {}
+  # capabilities:
+  #   drop:
+  #   - ALL
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+  # runAsUser: 1000
+
+service:
+  type: ClusterIP
+  port: 8000 # ingress port (but ingress is disabled since we're using istio virtualservice)
+  containerPort: 8000 # should be same as the one below
+
+doccanoconfig: 
+  admin_username: change
+  admin_email: change@me.com
+  admin_password: ChangeMe1234
+  db_url: "postgres://postgres_username:postgres_password@doccano-app-postgresql:5432/postgres_db?sslmode=disable"
+  # format: "postgres://postgres_username:postgres_password@postgres_host:postgres_port/postgres_db?sslmode=disable"
+  debug: True
+  standalone: True
+  secret_key: change-me-in-production-or-dont
+  port: 8000
+  workers: 3
+  celery_workers: 3
+  google_tracking_id: ""
+  django_settings_module: config.settings.production
+  persistant_storage_size: 2Gi
+
+
+postgresql:
+  #See https://github.com/bitnami/charts/blob/master/bitnami/postgresql/ for more info
+  enabled: true # If using your own hosted server disable this, and then modify doccanoconfig.db_url with your auth data
+  # If not external following config will be applied 
+  auth:
+    existingSecret: "{{ .Release.Name }}-postgres-secret"
+    username: postgres_username
+    database: postgres_db
+  service:
+    ports:
+      postgresql: 5432
+  secret:
+    create: true
+    name: "{{ .Release.Name }}-postgres-secret"
+    password: postgres_password
+    postgres_password: postgres_password_postgres
+    replication_password: postgres_password_replica
+
+ingress:
+  enabled: false
+  className: ""
+  annotations: {}
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+  hosts:
+    - host: doccano-app.com
+      paths:
+        - path: /
+          pathType: ImplementationSpecific
+  #tls:
+  #  - secretName: chart-example-tls
+  #   hosts:
+  #     - doccano-app
+
+resources: 
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  limits:
+    cpu: 2
+    memory: 4Gi
+  requests:
+    cpu: 1
+    memory: 2Gi
+
+autoscaling:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 100
+  targetCPUUtilizationPercentage: 80
+  # targetMemoryUtilizationPercentage: 80
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}


### PR DESCRIPTION
I added a basic helm chart. One already exists but is hard to find and not integrated in this repository. I tested it with microk8s running locally and kubernetes running on a more "production" environment.

I added it because its useful and several people expressed a need for it:

https://github.com/doccano/doccano/issues/2102

https://github.com/doccano/doccano/issues/882

https://github.com/doccano/doccano/issues/701

https://artifacthub.io/packages/helm/curie-df-helm-charts/doccano

Let me know if there are any fixes or improvements i should do, its my first time in a while contributing to an open source project so i might have gotten a bit rusty ;D .