### PR TITLE
Update an incorrectly implemented method

### DIFF
--- a/backend/data_import/pipeline/label.py
+++ b/backend/data_import/pipeline/label.py
@@ -26,7 +26,7 @@ class Label(BaseModel, abc.ABC):
 
     @abc.abstractmethod
     def __lt__(self, other):
-        raise NotImplementedError()
+        return NotImplemented
 
     @classmethod
     def parse(cls, example_uuid: UUID4, obj: Any):


### PR DESCRIPTION
In file: label.py, class: `Label`, there is a special method `__lt__` that raises a `NotImplementedError`. If a special method supporting a binary operation is not implemented it should return `NotImplemented`. On the other hand, `NotImplementedError` should be raised from abstract methods inside user defined base classes to indicate that derived classes should override those methods. I suggested that the special method `__lt__` should return `NotImplemented` instead of raising an exception. 

Sponsorship and Support:

This work is done by the security researchers from OpenRefactory and is supported by the [Open Source Security Foundation (OpenSSF)](https://openssf.org/): [Project Alpha-Omega](https://alpha-omega.dev/). Alpha-Omega is a project partnering with open source software project maintainers to systematically find new, as-yet-undiscovered vulnerabilities in open source code - and get them fixed – to improve global software supply chain security.

The bug is found by running the Intelligent Code Repair (iCR) tool by OpenRefactory and then manually triaging the results.