### PR TITLE
fix: make GOOGLE_APPLICATION_CREDENTIALS optional

### DIFF
--- a/backend/config/settings/gcp.py
+++ b/backend/config/settings/gcp.py
@@ -8,4 +8,11 @@ MIDDLEWARE.append("api.middleware.RangesMiddleware")  # noqa: F405
 DJANGO_DRF_FILEPOND_STORAGES_BACKEND = "storages.backends.gcloud.GoogleCloudStorage"
 GS_BUCKET_NAME = env("BUCKET_NAME", "doccano")
 GS_PROJECT_ID = env("GS_PROJECT_ID")
-GS_CREDENTIALS = service_account.Credentials.from_service_account_file(env("GOOGLE_APPLICATION_CREDENTIALS"))
+
+# for more details refer to
+# https://django-storages.readthedocs.io/en/latest/backends/gcloud.html#authentication-settings
+_google_application_credentials = env("GOOGLE_APPLICATION_CREDENTIALS", "")
+if _google_application_credentials:
+    GS_CREDENTIALS = service_account.Credentials.from_service_account_file(
+        _google_application_credentials
+    )


### PR DESCRIPTION
The variable can often be omitted in environments that use default credentials such as GKE (Google cloud's managed Kubernetes) or VM instances.

Django-storages also acknowledges this, and it provides GS_CREDENTIALS as a way around systems where the default credentials are not used or undesired.

However, it's impossible to not set the environment variable setting, and without passing a path to a valid file that contains a valid JSON structure of a service account key, this code will raise an error.

Refs:
* https://django-storages.readthedocs.io/en/latest/backends/gcloud.html#authentication-settings
* https://googleapis.dev/python/google-auth/latest/reference/google.auth.html#google.auth.default
* https://github.com/googleapis/google-auth-library-python/blob/d2ab3afdb567850121fec7de1d86fb5fb0fa80ed/google/oauth2/service_account.py#L643-L658
* https://github.com/googleapis/google-auth-library-python/blob/d2ab3afdb567850121fec7de1d86fb5fb0fa80ed/google/auth/_service_account_info.py#L78-L80