### PR TITLE
fix: use unicode error symbol � instead of failing to import data

### DIFF
--- a/backend/data_import/pipeline/parsers.py
+++ b/backend/data_import/pipeline/parsers.py
@@ -136,8 +136,8 @@ class TextFileParser(Parser):
 
     def parse(self, filename: str) -> Iterator[Dict[Any, Any]]:
         encoding = decide_encoding(filename, self.encoding)
-        with open(filename, encoding=encoding) as f:
-            yield {DEFAULT_TEXT_COLUMN: f.read()}
+        with open(filename, encoding=encoding, errors="replace") as f:
+            yield {DEFAULT_TEXT_COLUMN: f.read().replace("\x00", "\uFFFD")}
 
 
 class CSVParser(Parser):


### PR DESCRIPTION
Encoding detection is not a silver bullet, and some files can be broken inside, which ends up failing to import the whole batch of files (due to one broken file). For some tasks (sentiment detection), missing character is worth tradeoff. For other use-cases, at least the issue with encoding is presented to user in standardized way and on front-end - without looking into code, like I had to.

Replacement of null character (`\x00`) for � is required to successfully save data into PostgreSQL. 