### PR TITLE
add .gitattributes resolving windows LF to CRLF

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# Force LF for all shell scripts (because windows git might autoconvert LF to CRLF)
+*.sh text eol=lf
+

--- a/README.md
+++ b/README.md
@@ -115,12 +115,6 @@ git clone https://github.com/doccano/doccano.git
 cd doccano
 ```
 
-_Note for Windows developers:_ Be sure to configure git to correctly handle line endings or you may encounter `status code 127` errors while running the services in future steps. Running with the git config options below will ensure your git directory correctly handles line endings.
-
-```bash
-git clone https://github.com/doccano/doccano.git --config core.autocrlf=input
-```
-
 Then, create an `.env` file with variables in the following format (see [./docker/.env.example](https://github.com/doccano/doccano/blob/master/docker/.env.example)):
 
 ```plain


### PR DESCRIPTION
This commit adds a .gitattributes config that makes windows git clients respect LF line endings.

It is stated in the upstream README that windows devs need to manually work around this issue

> Note for Windows developers: ...

With this PR, that manual instruction wouldn't be necessary anymore.